### PR TITLE
Add OSGi metadata for use within Eclipse/OSGi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,26 +6,63 @@
   <groupId>com.google.cloud.tools.ide.login</groupId>
   <artifactId>com.google.cloud.tools.ide.login</artifactId>
   <version>0.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Login Support for Google Cloud Tools</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <archive>  
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive> 
+        </configuration>
+      </plugin>  
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>3.0.1</version>
+        <configuration>
+          <instructions>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>    
+              <goal>manifest</goal>
+            </goals>   
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
-        <groupId>com.google.apis</groupId>
-        <artifactId>google-api-services-oauth2</artifactId>
-        <version>v2-rev70-1.18.0-rc</version>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-oauth2</artifactId>
+      <version>v2-rev70-1.18.0-rc</version>
     </dependency>
     <dependency>
-        <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-jackson</artifactId>
-        <version>1.18.0-rc</version>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson</artifactId>
+      <version>1.18.0-rc</version>
     </dependency>
     <dependency>
-	    <groupId>com.google.guava</groupId>
-	    <artifactId>guava</artifactId>
-	    <version>19.0</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Use the Felix `maven-bundle-plugin` to generate OSGi metadata to allow the jar to be treated as a bundle.

PTAL @elharo 