### PR TITLE
OAuthDataStore impl using Java Preferences

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
@@ -447,7 +447,7 @@ public class GoogleLoginState {
     // the stored email can be null in the case where the external browser
     // was launched, because we can't extract the email from the external
     // browser
-    if (savedAuthState.getRefreshToken() == null || savedAuthState.getStoredScopes().size() == 0) {
+    if (savedAuthState.getRefreshToken() == null || savedAuthState.getStoredScopes().isEmpty()) {
       authDataStore.clearStoredOAuthData();
       return;
     }

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
@@ -447,7 +447,7 @@ public class GoogleLoginState {
     // the stored email can be null in the case where the external browser
     // was launched, because we can't extract the email from the external
     // browser
-    if (savedAuthState.getRefreshToken() == null || savedAuthState.getStoredScopes() == null) {
+    if (savedAuthState.getRefreshToken() == null || savedAuthState.getStoredScopes().size() == 0) {
       authDataStore.clearStoredOAuthData();
       return;
     }

--- a/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
@@ -1,25 +1,26 @@
-/*******************************************************************************
- * Copyright 2014 Google Inc. All Rights Reserved.
- * <p>
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * <p>
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 
 package com.google.cloud.tools.ide.login;
 
-import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
-import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -27,8 +28,8 @@ import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
 /**
- * Uses the standard Java Preferences for storing a particular user's {@link OAuthData} object persistently,
- * retrieving it, and clearing it.
+ * Uses the standard Java Preferences for storing a particular user's {@link OAuthData} object
+ * persistently, retrieving it, and clearing it.
  */
 public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
 
@@ -63,7 +64,8 @@ public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
 
   @Override
   public void saveOAuthData(OAuthData credential) {
-    Preconditions.checkNotNull(credential.getStoredScopes());  // Why? See OAuthData Javadoc.
+    // We rely on the fact that OAuthData.getStoredScopes() never returns null.
+    Preconditions.checkNotNull(credential.getStoredScopes());
     for (String scopes : credential.getStoredScopes()) {
       Preconditions.checkArgument(
           !scopes.contains(SCOPE_DELIMITER), "Scopes must not have a delimiter character.");

--- a/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright 2014 Google Inc. All Rights Reserved.
+ * <p>
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package com.google.cloud.tools.ide.login;
+
+import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+
+/**
+ * Uses the standard Java Preferences for storing a particular user's {@link OAuthData} object persistently,
+ * retrieving it, and clearing it.
+ */
+public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
+
+  private String preferencePath;
+  private LoggerFacade logger;
+
+  private static final String KEY_ACCESS_TOKEN = "access_token";
+  private static final String KEY_REFRESH_TOKEN = "refresh_token";
+  private static final String KEY_EMAIL = "email";
+  private static final String KEY_ACCESS_TOKEN_EXPIRY_TIME = "access_token_expiry_time";
+  private static final String KEY_OAUTH_SCOPES = "oauth_scopes";
+
+  @VisibleForTesting
+  static final String SCOPE_DELIMITER = " ";
+
+  JavaPreferenceOAuthDataStore(String preferencePath, LoggerFacade logger) {
+    this.preferencePath = preferencePath;
+    this.logger = logger;
+  }
+
+  @Override
+  public void clearStoredOAuthData() {
+    Preferences prefs = Preferences.userRoot().node(preferencePath);
+
+    prefs.remove(KEY_ACCESS_TOKEN);
+    prefs.remove(KEY_REFRESH_TOKEN);
+    prefs.remove(KEY_EMAIL);
+    prefs.remove(KEY_OAUTH_SCOPES);
+    prefs.remove(KEY_ACCESS_TOKEN_EXPIRY_TIME);
+    flushPrefs(prefs);
+  }
+
+  @Override
+  public void saveOAuthData(OAuthData credential) {
+    Preconditions.checkNotNull(credential.getStoredScopes());  // Why? See OAuthData Javadoc.
+    for (String scopes : credential.getStoredScopes()) {
+      Preconditions.checkArgument(
+          !scopes.contains(SCOPE_DELIMITER), "Scopes must not have a delimiter character.");
+    }
+
+    Preferences prefs = Preferences.userRoot().node(preferencePath);
+
+    prefs.put(KEY_ACCESS_TOKEN, Strings.nullToEmpty(credential.getAccessToken()));
+    prefs.put(KEY_REFRESH_TOKEN, Strings.nullToEmpty(credential.getRefreshToken()));
+    prefs.put(KEY_EMAIL, Strings.nullToEmpty(credential.getStoredEmail()));
+    prefs.putLong(KEY_ACCESS_TOKEN_EXPIRY_TIME, credential.getAccessTokenExpiryTime());
+    prefs.put(KEY_OAUTH_SCOPES, Joiner.on(SCOPE_DELIMITER).join(credential.getStoredScopes()));
+
+    flushPrefs(prefs);
+  }
+
+  @Override
+  public OAuthData loadOAuthData() {
+    Preferences prefs = Preferences.userRoot().node(preferencePath);
+
+    String accessToken = Strings.emptyToNull(prefs.get(KEY_ACCESS_TOKEN, null));
+    String refreshToken = Strings.emptyToNull(prefs.get(KEY_REFRESH_TOKEN, null));
+    String email = Strings.emptyToNull(prefs.get(KEY_EMAIL, null));
+    long accessTokenExpiryTime = prefs.getLong(KEY_ACCESS_TOKEN_EXPIRY_TIME, 0);
+    String scopesString = prefs.get(KEY_OAUTH_SCOPES, "");
+
+    Set<String> oauthScopes = new HashSet<>(
+        Splitter.on(SCOPE_DELIMITER).omitEmptyStrings().splitToList(scopesString));
+
+    return new OAuthData(accessToken, refreshToken, email, oauthScopes, accessTokenExpiryTime);
+  }
+
+  private void flushPrefs(Preferences prefs) {
+    try {
+      prefs.flush();
+    } catch (BackingStoreException bse) {
+      logger.logWarning("Could not flush preferences: " + bse.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/tools/ide/login/OAuthData.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/OAuthData.java
@@ -34,6 +34,9 @@ public class OAuthData {
   @Nullable private final long accessTokenExpiryTime;
   private final Set<String> storedScopes;
 
+  /**
+   * @param scopes if null, an empty set will be created and set
+   */
   public OAuthData(
       @Nullable String accessToken, @Nullable String refreshToken, @Nullable String storedEmail,
       @Nullable Set<String> scopes, @Nullable long accessTokenExpiryTime) {
@@ -49,7 +52,6 @@ public class OAuthData {
     return storedEmail;
   }
 
-  @Nullable
   public Set<String> getStoredScopes() {
     return storedScopes;
   }

--- a/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
@@ -1,0 +1,145 @@
+package com.google.cloud.tools.ide.login;
+
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JavaPreferenceOAuthDataStoreTest {
+
+  @Mock private LoggerFacade logger;
+
+  private Preferences prefs = Preferences.userRoot().node("some preference node");
+  private JavaPreferenceOAuthDataStore dataStore =
+    new JavaPreferenceOAuthDataStore(prefs.name(), logger);
+
+  @Test
+  public void testLoadOAuthData_returnEmptyOAuthData() {
+    OAuthData loaded = dataStore.loadOAuthData();
+
+    Assert.assertNull(loaded.getAccessToken());
+    Assert.assertNull(loaded.getRefreshToken());
+    Assert.assertNull(loaded.getStoredEmail());
+    Assert.assertEquals(0, loaded.getStoredScopes().size());
+    Assert.assertEquals(0, loaded.getAccessTokenExpiryTime());
+  }
+
+  @Test
+  public void testSaveLoadOAuthData() {
+    Set<String> scopes = new HashSet<String>(Arrays.asList("my-scope1", "my-scope2"));
+    OAuthData oauthData = new OAuthData(
+        "my-access-token", "my-refresh-token", "my-email", scopes, 12345);
+
+    dataStore.saveOAuthData(oauthData);
+    OAuthData loaded = dataStore.loadOAuthData();
+
+    Assert.assertEquals("my-access-token", loaded.getAccessToken());
+    Assert.assertEquals("my-refresh-token", loaded.getRefreshToken());
+    Assert.assertEquals("my-email", loaded.getStoredEmail());
+    Assert.assertEquals(scopes, loaded.getStoredScopes());
+    Assert.assertEquals(12345, loaded.getAccessTokenExpiryTime());
+  }
+
+  @Test
+  public void testSaveLoadOAuthData_nullValues() {
+    OAuthData oauthData = new OAuthData(null, null, null, null, 0);
+
+    dataStore.saveOAuthData(oauthData);
+    OAuthData loaded = dataStore.loadOAuthData();
+
+    Assert.assertEquals(null, loaded.getAccessToken());
+    Assert.assertEquals(null, loaded.getRefreshToken());
+    Assert.assertEquals(null, loaded.getStoredEmail());
+    Assert.assertEquals(0, loaded.getStoredScopes().size());
+    Assert.assertEquals(0, loaded.getAccessTokenExpiryTime());
+  }
+
+  @Test
+  public void testSaveLoadOAuthData_emptyValues() {
+    OAuthData oauthData = new OAuthData("", "", "", null, 0);
+
+    dataStore.saveOAuthData(oauthData);
+    OAuthData loaded = dataStore.loadOAuthData();
+
+    Assert.assertEquals(null, loaded.getAccessToken());
+    Assert.assertEquals(null, loaded.getRefreshToken());
+    Assert.assertEquals(null, loaded.getStoredEmail());
+    Assert.assertEquals(0, loaded.getStoredScopes().size());
+    Assert.assertEquals(0, loaded.getAccessTokenExpiryTime());
+  }
+
+  @Test
+  public void testSaveClearLoadOAuthData_returnEmptyOAuthData() {
+    Set<String> scopes = new HashSet<String>(Arrays.asList("my-scope1", "my-scope2"));
+    OAuthData oauthData = new OAuthData(
+        "my-access-token", "my-refresh-token", "my-email", scopes, 12345);
+
+    dataStore.saveOAuthData(oauthData);
+    dataStore.clearStoredOAuthData();
+    OAuthData loaded = dataStore.loadOAuthData();
+
+    Assert.assertNull(loaded.getAccessToken());
+    Assert.assertNull(loaded.getRefreshToken());
+    Assert.assertNull(loaded.getStoredEmail());
+    Assert.assertEquals(0, loaded.getStoredScopes().size());
+    Assert.assertEquals(0, loaded.getAccessTokenExpiryTime());
+  }
+
+  @Test
+  public void testSaveLoadOAuthData_nullScopeSet() {
+    OAuthData oauthData = new OAuthData("my-access-token", "my-refresh-token", "my-email",
+        null, 12345);
+
+    dataStore.saveOAuthData(oauthData);
+    OAuthData loaded = dataStore.loadOAuthData();
+
+    Assert.assertEquals("my-access-token", loaded.getAccessToken());
+    Assert.assertEquals("my-refresh-token", loaded.getRefreshToken());
+    Assert.assertEquals("my-email", loaded.getStoredEmail());
+    Assert.assertEquals(0, loaded.getStoredScopes().size());
+    Assert.assertEquals(12345, loaded.getAccessTokenExpiryTime());
+  }
+
+  @Test
+  public void testSaveLoadOAuthData_emptyScopeSet() {
+    OAuthData oauthData = new OAuthData("my-access-token", "my-refresh-token", "my-email",
+        new HashSet<String>(), 12345);
+
+    dataStore.saveOAuthData(oauthData);
+    OAuthData loaded = dataStore.loadOAuthData();
+
+    Assert.assertEquals("my-access-token", loaded.getAccessToken());
+    Assert.assertEquals("my-refresh-token", loaded.getRefreshToken());
+    Assert.assertEquals("my-email", loaded.getStoredEmail());
+    Assert.assertEquals(0, loaded.getStoredScopes().size());
+    Assert.assertEquals(12345, loaded.getAccessTokenExpiryTime());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSaveOAuthData_scopeWithDelimiter() {
+    Set<String> scopes = new HashSet<>(Arrays.asList(JavaPreferenceOAuthDataStore.SCOPE_DELIMITER,
+        "head" + JavaPreferenceOAuthDataStore.SCOPE_DELIMITER + "tail"));
+    OAuthData oauthData = new OAuthData(null, null, null, scopes, 0);
+
+    dataStore.saveOAuthData(oauthData);
+  }
+
+  @After
+  public void tearDown() {
+    try {
+      prefs.clear();
+    } catch (BackingStoreException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
@@ -1,6 +1,5 @@
 package com.google.cloud.tools.ide.login;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
Java Preference Implementation of `OAuthDataStore`.

Misc:

- IntelliJ IDE changed `pom.xml` to allow using `@Override`.
- The Javadoc of `OAuthData` says that the `Set` for storing scopes is never null:

  ```
/**
 * Authentication data, consisting of an access token, a refresh token, an access-token expiration
 * time, and a user email address, each of which may be null, and a set of authorized scopes that is
 * never null but may be empty.
 */
  ```
 In fact, `OAuthData` creates an empty set if a null set is given, and `OAuthData.getStoredSet()` never returns null.