### PR TITLE
Eliminate warnings / clean up and simplify code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
         <configuration>
           <source>1.7</source>
           <target>1.7</target>

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
@@ -280,7 +280,7 @@ public class GoogleLoginState {
       return false;
     }
     isLoggedIn = true;
-    updateCredentials(authResponse);
+    updateLoginState(authResponse);
     return true;
   }
 
@@ -330,7 +330,7 @@ public class GoogleLoginState {
       return false;
     }
     isLoggedIn = true;
-    updateCredentials(authResponse);
+    updateLoginState(authResponse);
     return true;
   }
 
@@ -401,7 +401,7 @@ public class GoogleLoginState {
     uiFacade.notifyStatusIndicator();
   }
 
-  private void updateCredentials(GoogleTokenResponse tokenResponse) {
+  private void updateLoginState(GoogleTokenResponse tokenResponse) {
     refreshToken = tokenResponse.getRefreshToken();
     accessToken = tokenResponse.getAccessToken();
     oAuth2Credential = makeCredential();

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Collection;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
@@ -140,8 +140,8 @@ public class GoogleLoginState {
    * if it is expired.
    *
    * @return an OAuth2 token
-   * @throws IOException if something goes wrong while fetching the token
    * @throws IllegalStateException if no user is currently signed in
+   * @throws IOException if something goes wrong while fetching the token
    */
   public String fetchAccessToken() throws IOException {
     Preconditions.checkState(isLoggedIn);
@@ -181,8 +181,8 @@ public class GoogleLoginState {
    * token. This token is short lived.
    *
    * @return an OAuth2 token
-   * @throws IOException if something goes wrong while fetching the token
    * @throws IllegalStateException if no user is currently signed in
+   * @throws IOException if something goes wrong while fetching the token
    *
    */
   public String fetchOAuth2Token() throws IOException {

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
@@ -400,7 +400,7 @@ public class GoogleLoginState {
     uiFacade.notifyStatusIndicator();
   }
 
-  private void logInHelper(GoogleTokenResponse tokenResponse) {
+  private void updateCredentials(GoogleTokenResponse tokenResponse) {
     refreshToken = tokenResponse.getRefreshToken();
     accessToken = tokenResponse.getAccessToken();
     oAuth2Credential = makeCredential();

--- a/src/test/java/com/google/cloud/tools/ide/login/GoogleLoginStateTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/GoogleLoginStateTest.java
@@ -25,7 +25,6 @@ public class GoogleLoginStateTest {
         authDataStore, uiFacade, loggerFacade);
     
     Assert.assertFalse(state.isLoggedIn());
-    Assert.assertTrue(state.isConnected());
   }
   
 }


### PR DESCRIPTION
I had this code clean-up hanging around for a while.

A few points in this code clean-up:
- `connected` has always been true, so it's essentially meaningless.
- Removed the private method `checkLoggedIn()`, which automatically pops up a login browser if no one is logged in. It wasn't compatible with the login flow using a local server, so it shouldn't be used anyway. For the existing places where `checkLoggedIn()` is used, I enforced the precondition that the class should be in a logged-in state.
- There had been mixed use of `GregorianCalendar().getTimeInMillis()` and `System.currentTimeMillis()`.
- Changed method names to eliminate confusion.

@nbashirbello @elharo @briandealwis @akerekes