### PR TITLE
Persist multiple accounts

### DIFF
--- a/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
@@ -38,7 +38,6 @@ public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
 
   private static final String KEY_ACCESS_TOKEN = "access_token";
   private static final String KEY_REFRESH_TOKEN = "refresh_token";
-  private static final String KEY_EMAIL = "email";
   private static final String KEY_ACCESS_TOKEN_EXPIRY_TIME = "access_token_expiry_time";
   private static final String KEY_OAUTH_SCOPES = "oauth_scopes";
 
@@ -52,57 +51,70 @@ public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
 
   @Override
   public void clearStoredOAuthData() {
-    Preferences prefs = Preferences.userRoot().node(preferencePath);
-
-    prefs.remove(KEY_ACCESS_TOKEN);
-    prefs.remove(KEY_REFRESH_TOKEN);
-    prefs.remove(KEY_EMAIL);
-    prefs.remove(KEY_OAUTH_SCOPES);
-    prefs.remove(KEY_ACCESS_TOKEN_EXPIRY_TIME);
-    flushPrefs(prefs);
+    removeNode(Preferences.userRoot().node(preferencePath));
   }
 
   @Override
-  public void saveOAuthData(OAuthData credential) {
-    // We rely on the fact that OAuthData.getStoredScopes() never returns null.
-    Preconditions.checkNotNull(credential.getStoredScopes());
-    for (String scopes : credential.getStoredScopes()) {
+  public void removeOAuthData(String email) {
+    removeNode(Preferences.userRoot().node(preferencePath).node(email));
+  }
+
+  @Override
+  public void saveOAuthData(OAuthData oAuthData) {
+    Preconditions.checkNotNull(oAuthData.getEmail());
+    Preconditions.checkNotNull(oAuthData.getStoredScopes());
+    for (String scopes : oAuthData.getStoredScopes()) {
       Preconditions.checkArgument(
           !scopes.contains(SCOPE_DELIMITER), "Scopes must not have a delimiter character.");
     }
 
-    Preferences prefs = Preferences.userRoot().node(preferencePath);
+    Preferences accountNode =
+        Preferences.userRoot().node(preferencePath).node(oAuthData.getEmail());
 
-    prefs.put(KEY_ACCESS_TOKEN, Strings.nullToEmpty(credential.getAccessToken()));
-    prefs.put(KEY_REFRESH_TOKEN, Strings.nullToEmpty(credential.getRefreshToken()));
-    prefs.put(KEY_EMAIL, Strings.nullToEmpty(credential.getStoredEmail()));
-    prefs.putLong(KEY_ACCESS_TOKEN_EXPIRY_TIME, credential.getAccessTokenExpiryTime());
-    prefs.put(KEY_OAUTH_SCOPES, Joiner.on(SCOPE_DELIMITER).join(credential.getStoredScopes()));
+    accountNode.put(KEY_ACCESS_TOKEN, Strings.nullToEmpty(oAuthData.getAccessToken()));
+    accountNode.put(KEY_REFRESH_TOKEN, Strings.nullToEmpty(oAuthData.getRefreshToken()));
+    accountNode.putLong(KEY_ACCESS_TOKEN_EXPIRY_TIME, oAuthData.getAccessTokenExpiryTime());
+    accountNode.put(KEY_OAUTH_SCOPES, Joiner.on(SCOPE_DELIMITER).join(oAuthData.getStoredScopes()));
 
-    flushPrefs(prefs);
+    try {
+      accountNode.flush();
+    } catch (BackingStoreException bse) {
+      logger.logWarning("Could not flush preferences: " + bse.getMessage());
+    }
   }
 
   @Override
-  public OAuthData loadOAuthData() {
-    Preferences prefs = Preferences.userRoot().node(preferencePath);
-
-    String accessToken = Strings.emptyToNull(prefs.get(KEY_ACCESS_TOKEN, null));
-    String refreshToken = Strings.emptyToNull(prefs.get(KEY_REFRESH_TOKEN, null));
-    String email = Strings.emptyToNull(prefs.get(KEY_EMAIL, null));
-    long accessTokenExpiryTime = prefs.getLong(KEY_ACCESS_TOKEN_EXPIRY_TIME, 0);
-    String scopesString = prefs.get(KEY_OAUTH_SCOPES, "");
-
-    Set<String> oauthScopes = new HashSet<>(
-        Splitter.on(SCOPE_DELIMITER).omitEmptyStrings().splitToList(scopesString));
-
-    return new OAuthData(accessToken, refreshToken, email, oauthScopes, accessTokenExpiryTime);
-  }
-
-  private void flushPrefs(Preferences prefs) {
+  public Set<OAuthData> loadOAuthData() {
+    Set<OAuthData> oAuthDataSet = new HashSet<>();
     try {
-      prefs.flush();
+      Preferences prefs = Preferences.userRoot().node(preferencePath);
+
+      for (String email : prefs.childrenNames()) {
+        Preferences accountNode = prefs.node(email);
+
+        String accessToken = Strings.emptyToNull(accountNode.get(KEY_ACCESS_TOKEN, null));
+        String refreshToken = Strings.emptyToNull(accountNode.get(KEY_REFRESH_TOKEN, null));
+        long accessTokenExpiryTime = accountNode.getLong(KEY_ACCESS_TOKEN_EXPIRY_TIME, 0);
+        String scopesString = accountNode.get(KEY_OAUTH_SCOPES, "");
+
+        Set<String> oAuthScopes = new HashSet<>(
+            Splitter.on(SCOPE_DELIMITER).omitEmptyStrings().splitToList(scopesString));
+
+        oAuthDataSet.add(
+            new OAuthData(accessToken, refreshToken, email, oAuthScopes, accessTokenExpiryTime));
+      }
     } catch (BackingStoreException bse) {
       logger.logWarning("Could not flush preferences: " + bse.getMessage());
+    }
+    return oAuthDataSet;
+  }
+
+  private void removeNode(Preferences node) {
+    try {
+      node.removeNode();
+      node.flush();
+    } catch (BackingStoreException bse) {
+      logger.logWarning("Could not remove preferences node: " + bse.getMessage());
     }
   }
 }

--- a/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
@@ -56,13 +56,13 @@ public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
   }
 
   @Override
-  public void clearStoredOAuthData() {
-    removeNode(Preferences.userRoot().node(preferencePath));
+  public void removeOAuthData(String email) {
+    removeNode(Preferences.userRoot().node(preferencePath).node(email));
   }
 
   @Override
-  public void removeOAuthData(String email) {
-    removeNode(Preferences.userRoot().node(preferencePath).node(email));
+  public void clearStoredOAuthData() {
+    removeNode(Preferences.userRoot().node(preferencePath));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
@@ -44,6 +44,10 @@ public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
   @VisibleForTesting
   static final String SCOPE_DELIMITER = " ";
 
+  /**
+   * @param preferencePath the path name of the root preference node. This node must be exclusive
+   *     to this data store (i.e., must not be shared to save other preferences).
+   */
   public JavaPreferenceOAuthDataStore(String preferencePath, LoggerFacade logger) {
     this.preferencePath = preferencePath;
     this.logger = logger;
@@ -113,6 +117,8 @@ public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
     try {
       node.removeNode();
       node.flush();
+    } catch (IllegalStateException ise) {
+      // Thrown if this node (or an ancestor) has already been removed; ignore.
     } catch (BackingStoreException bse) {
       logger.logWarning("Could not remove preferences node: " + bse.getMessage());
     }

--- a/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
@@ -30,6 +30,8 @@ import java.util.prefs.Preferences;
 /**
  * Uses the standard Java Preferences for storing a particular user's {@link OAuthData} object
  * persistently, retrieving it, and clearing it.
+ *
+ * Not thread-safe.
  */
 public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
 

--- a/src/main/java/com/google/cloud/tools/ide/login/OAuthData.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/OAuthData.java
@@ -1,19 +1,22 @@
-/*******************************************************************************
- * Copyright 2014 Google Inc. All Rights Reserved.
- * 
- * All rights reserved. This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License v1.0 which
- * accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.ide.login;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
@@ -28,7 +31,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public class OAuthData {
-  @Nullable private final String storedEmail;
+  private final String email;
   @Nullable private final String accessToken;
   @Nullable private final String refreshToken;
   private final long accessTokenExpiryTime;
@@ -37,19 +40,19 @@ public class OAuthData {
   /**
    * @param scopes if null, an empty set will be created and set
    */
-  public OAuthData(
-      @Nullable String accessToken, @Nullable String refreshToken, @Nullable String storedEmail,
+  public OAuthData(@Nullable String accessToken, @Nullable String refreshToken, String email,
       @Nullable Set<String> scopes, long accessTokenExpiryTime) {
+    Preconditions.checkNotNull(email);
+
     this.accessToken = accessToken;
     this.refreshToken = refreshToken;
-    this.storedEmail = storedEmail;
+    this.email = email;
     this.storedScopes = (scopes == null ? ImmutableSet.<String>of() : scopes);
     this.accessTokenExpiryTime = accessTokenExpiryTime;
   }
 
-  @Nullable
-  public String getStoredEmail() {
-    return storedEmail;
+  public String getEmail() {
+    return email;
   }
 
   public Set<String> getStoredScopes() {

--- a/src/main/java/com/google/cloud/tools/ide/login/OAuthDataStore.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/OAuthDataStore.java
@@ -1,41 +1,46 @@
-/*******************************************************************************
- * Copyright 2014 Google Inc. All Rights Reserved.
- * 
- * All rights reserved. This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License v1.0 which
- * accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- * 
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.ide.login;
+
+import java.util.Set;
 
 /**
  * Presents a common API, implementable on a variety of platforms, for storing a particular user's
  * {@link OAuthData} object persistently, retrieving it, and clearing it.
  */
 public interface OAuthDataStore {
-  
+
   /**
    * Stores a specified {@link OAuthData} object persistently.
-   * 
-   * @param credentials the specified {@code Credentials object}
    */
-  void saveOAuthData(OAuthData credentials);
-  
+  void saveOAuthData(OAuthData oAuthData);
+
   /**
-   * Retrieves the persistently stored {@link OAuthData} object, if any.
+   * Retrieves the persistently stored {@link OAuthData} objects, if any.
    * 
-   * @return
-   *     if there is a persistently stored {@code OAuthData} object, that object; otherwise an
-   *     {@code OAuthData} object all of whose getters return {@code null}
+   * @return never {@code null}
    */
-  OAuthData loadOAuthData();
-  
+  Set<OAuthData> loadOAuthData();
+
+  /**
+   * Removes a stored {@link OAuthData} matching the given {@code email}, in any.
+   */
+  void removeOAuthData(String email);
+
   /**
    * Clears the persistently stored {@link OAuthData} object, if any.
    */

--- a/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
@@ -1,14 +1,36 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.ide.login;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
@@ -16,129 +38,155 @@ import java.util.prefs.Preferences;
 @RunWith(MockitoJUnitRunner.class)
 public class JavaPreferenceOAuthDataStoreTest {
 
+  private static final Set<String> FAKE_OAUTH_SCOPES = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList("my-scope1", "my-scope2")));
+
+  private static final OAuthData[] fakeOAuthData = new OAuthData[] {
+      new OAuthData("accessToken1", "refreshToken1", "email1@example.com", FAKE_OAUTH_SCOPES, 123),
+      new OAuthData("accessToken2", "refreshToken2", "email2@example.com", FAKE_OAUTH_SCOPES, 234),
+      new OAuthData("accessToken3", "refreshToken3", "email3@example.com", FAKE_OAUTH_SCOPES, 345)
+  };
+
   @Mock private LoggerFacade logger;
 
-  private Preferences prefs = Preferences.userRoot().node("some preference node");
   private JavaPreferenceOAuthDataStore dataStore =
-    new JavaPreferenceOAuthDataStore(prefs.name(), logger);
+      new JavaPreferenceOAuthDataStore("some_test_preference_path", logger);
 
   @Test
   public void testLoadOAuthData_returnEmptyOAuthData() {
-    OAuthData loaded = dataStore.loadOAuthData();
-
-    Assert.assertNull(loaded.getAccessToken());
-    Assert.assertNull(loaded.getRefreshToken());
-    Assert.assertNull(loaded.getStoredEmail());
-    Assert.assertEquals(0, loaded.getStoredScopes().size());
-    Assert.assertEquals(0, loaded.getAccessTokenExpiryTime());
+    assertTrue(dataStore.loadOAuthData().isEmpty());
   }
 
   @Test
   public void testSaveLoadOAuthData() {
-    Set<String> scopes = new HashSet<String>(Arrays.asList("my-scope1", "my-scope2"));
-    OAuthData oauthData = new OAuthData(
-        "my-access-token", "my-refresh-token", "my-email", scopes, 12345);
+    dataStore.saveOAuthData(fakeOAuthData[0]);
+    verifyContains(dataStore.loadOAuthData(), fakeOAuthData[0]);
+  }
 
-    dataStore.saveOAuthData(oauthData);
-    OAuthData loaded = dataStore.loadOAuthData();
+  @Test
+  public void testSaveLoadOAuthData_multipleCredentials() {
+    saveThreeFakeOAuthData();
 
-    Assert.assertEquals("my-access-token", loaded.getAccessToken());
-    Assert.assertEquals("my-refresh-token", loaded.getRefreshToken());
-    Assert.assertEquals("my-email", loaded.getStoredEmail());
-    Assert.assertEquals(scopes, loaded.getStoredScopes());
-    Assert.assertEquals(12345, loaded.getAccessTokenExpiryTime());
+    Set<OAuthData> loaded = dataStore.loadOAuthData();
+    assertEquals(3, loaded.size());
+    verifyContains(loaded, fakeOAuthData[0]);
+    verifyContains(loaded, fakeOAuthData[1]);
+    verifyContains(loaded, fakeOAuthData[2]);
+  }
+
+  @Test
+  public void testRemoveOAuthData() {
+    saveThreeFakeOAuthData();
+    dataStore.removeOAuthData("email1@example.com");
+    dataStore.removeOAuthData("email3@example.com");
+
+    assertEquals(1, dataStore.loadOAuthData().size());
+    verifyContains(dataStore.loadOAuthData(), fakeOAuthData[1]);
+  }
+
+  @Test
+  public void testRemoveOAuthData_nonExistingEmail() {
+    saveThreeFakeOAuthData();
+    dataStore.removeOAuthData("email999@example.com");
+
+    Set<OAuthData> loaded = dataStore.loadOAuthData();
+    assertEquals(3, loaded.size());
+    verifyContains(loaded, fakeOAuthData[0]);
+    verifyContains(loaded, fakeOAuthData[1]);
+    verifyContains(loaded, fakeOAuthData[2]);
   }
 
   @Test
   public void testSaveLoadOAuthData_nullValues() {
-    OAuthData oauthData = new OAuthData(null, null, null, null, 0);
+    dataStore.saveOAuthData(new OAuthData(null, null, "email@example.com", null, 0));
+    OAuthData loaded = dataStore.loadOAuthData().iterator().next();
 
-    dataStore.saveOAuthData(oauthData);
-    OAuthData loaded = dataStore.loadOAuthData();
-
-    Assert.assertEquals(null, loaded.getAccessToken());
-    Assert.assertEquals(null, loaded.getRefreshToken());
-    Assert.assertEquals(null, loaded.getStoredEmail());
-    Assert.assertEquals(0, loaded.getStoredScopes().size());
-    Assert.assertEquals(0, loaded.getAccessTokenExpiryTime());
+    assertNull(loaded.getAccessToken());
+    assertNull(loaded.getRefreshToken());
+    assertEquals("email@example.com", loaded.getEmail());
+    assertTrue(loaded.getStoredScopes().isEmpty());
+    assertEquals(0, loaded.getAccessTokenExpiryTime());
   }
 
   @Test
   public void testSaveLoadOAuthData_emptyValues() {
-    OAuthData oauthData = new OAuthData("", "", "", null, 0);
+    dataStore.saveOAuthData(new OAuthData("", "", "email@example.com", null, 0));
+    OAuthData loaded = dataStore.loadOAuthData().iterator().next();
 
-    dataStore.saveOAuthData(oauthData);
-    OAuthData loaded = dataStore.loadOAuthData();
-
-    Assert.assertEquals(null, loaded.getAccessToken());
-    Assert.assertEquals(null, loaded.getRefreshToken());
-    Assert.assertEquals(null, loaded.getStoredEmail());
-    Assert.assertEquals(0, loaded.getStoredScopes().size());
-    Assert.assertEquals(0, loaded.getAccessTokenExpiryTime());
+    assertNull(loaded.getAccessToken());
+    assertNull(loaded.getRefreshToken());
+    assertEquals("email@example.com", loaded.getEmail());
+    assertTrue(loaded.getStoredScopes().isEmpty());
+    assertEquals(0, loaded.getAccessTokenExpiryTime());
   }
 
   @Test
-  public void testSaveClearLoadOAuthData_returnEmptyOAuthData() {
-    Set<String> scopes = new HashSet<String>(Arrays.asList("my-scope1", "my-scope2"));
-    OAuthData oauthData = new OAuthData(
-        "my-access-token", "my-refresh-token", "my-email", scopes, 12345);
+  public void testSaveLoadOAuthData_emptyEmail() {
+    dataStore.saveOAuthData(new OAuthData(null, null, "", null, 0));
+    assertTrue(dataStore.loadOAuthData().isEmpty());
+  }
 
-    dataStore.saveOAuthData(oauthData);
+  @Test
+  public void testSaveClearLoadOAuthData() {
+    saveThreeFakeOAuthData();
     dataStore.clearStoredOAuthData();
-    OAuthData loaded = dataStore.loadOAuthData();
-
-    Assert.assertNull(loaded.getAccessToken());
-    Assert.assertNull(loaded.getRefreshToken());
-    Assert.assertNull(loaded.getStoredEmail());
-    Assert.assertEquals(0, loaded.getStoredScopes().size());
-    Assert.assertEquals(0, loaded.getAccessTokenExpiryTime());
+    assertTrue(dataStore.loadOAuthData().isEmpty());
   }
 
   @Test
   public void testSaveLoadOAuthData_nullScopeSet() {
-    OAuthData oauthData = new OAuthData("my-access-token", "my-refresh-token", "my-email",
-        null, 12345);
+    dataStore.saveOAuthData(new OAuthData("accessToken", "refreshToken", "email", null, 123));
+    OAuthData loaded = dataStore.loadOAuthData().iterator().next();
 
-    dataStore.saveOAuthData(oauthData);
-    OAuthData loaded = dataStore.loadOAuthData();
-
-    Assert.assertEquals("my-access-token", loaded.getAccessToken());
-    Assert.assertEquals("my-refresh-token", loaded.getRefreshToken());
-    Assert.assertEquals("my-email", loaded.getStoredEmail());
-    Assert.assertEquals(0, loaded.getStoredScopes().size());
-    Assert.assertEquals(12345, loaded.getAccessTokenExpiryTime());
+    assertEquals("accessToken", loaded.getAccessToken());
+    assertEquals("refreshToken", loaded.getRefreshToken());
+    assertEquals("email", loaded.getEmail());
+    assertTrue(loaded.getStoredScopes().isEmpty());
+    assertEquals(123, loaded.getAccessTokenExpiryTime());
   }
 
   @Test
   public void testSaveLoadOAuthData_emptyScopeSet() {
-    OAuthData oauthData = new OAuthData("my-access-token", "my-refresh-token", "my-email",
-        new HashSet<String>(), 12345);
+    OAuthData oAuthData =
+        new OAuthData("accessToken", "refreshToken", "email", new HashSet<String>(), 123);
 
-    dataStore.saveOAuthData(oauthData);
-    OAuthData loaded = dataStore.loadOAuthData();
-
-    Assert.assertEquals("my-access-token", loaded.getAccessToken());
-    Assert.assertEquals("my-refresh-token", loaded.getRefreshToken());
-    Assert.assertEquals("my-email", loaded.getStoredEmail());
-    Assert.assertEquals(0, loaded.getStoredScopes().size());
-    Assert.assertEquals(12345, loaded.getAccessTokenExpiryTime());
+    dataStore.saveOAuthData(oAuthData);
+    Set<OAuthData> loaded = dataStore.loadOAuthData();
+    assertEquals(1, loaded.size());
+    verifyContains(loaded, oAuthData);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testSaveOAuthData_scopeWithDelimiter() {
     Set<String> scopes = new HashSet<>(Arrays.asList(JavaPreferenceOAuthDataStore.SCOPE_DELIMITER,
         "head" + JavaPreferenceOAuthDataStore.SCOPE_DELIMITER + "tail"));
-    OAuthData oauthData = new OAuthData(null, null, null, scopes, 0);
+    OAuthData oAuthData = new OAuthData(null, null, "email@example.com", scopes, 0);
 
-    dataStore.saveOAuthData(oauthData);
+    dataStore.saveOAuthData(oAuthData);
   }
 
   @After
-  public void tearDown() {
-    try {
-      prefs.clear();
-    } catch (BackingStoreException e) {
-      e.printStackTrace();
+  public void tearDown() throws BackingStoreException {
+    dataStore.clearStoredOAuthData();
+    Preferences.userRoot().node("some test preference path").removeNode();
+  }
+
+  private void saveThreeFakeOAuthData() {
+    dataStore.saveOAuthData(fakeOAuthData[0]);
+    dataStore.saveOAuthData(fakeOAuthData[1]);
+    dataStore.saveOAuthData(fakeOAuthData[2]);
+  }
+
+  private void verifyContains(Set<OAuthData> oAuthDataSet, OAuthData oAuthDataToMatch) {
+    for (OAuthData oAuthData : oAuthDataSet) {
+      if (Objects.equals(oAuthData.getEmail(), oAuthDataToMatch.getEmail())
+        && Objects.equals(oAuthData.getAccessToken(), oAuthDataToMatch.getAccessToken())
+          && Objects.equals(oAuthData.getRefreshToken(), oAuthDataToMatch.getRefreshToken())
+          && Objects.equals(oAuthData.getStoredScopes(), oAuthDataToMatch.getStoredScopes())
+          && oAuthData.getAccessTokenExpiryTime() == oAuthDataToMatch.getAccessTokenExpiryTime()) {
+        return;
+      }
     }
+    fail();
   }
 }

--- a/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
@@ -65,39 +65,6 @@ public class JavaPreferenceOAuthDataStoreTest {
   }
 
   @Test
-  public void testSaveLoadOAuthData_multipleCredentials() {
-    saveThreeFakeOAuthData();
-
-    Set<OAuthData> loaded = dataStore.loadOAuthData();
-    assertEquals(3, loaded.size());
-    verifyContains(loaded, fakeOAuthData[0]);
-    verifyContains(loaded, fakeOAuthData[1]);
-    verifyContains(loaded, fakeOAuthData[2]);
-  }
-
-  @Test
-  public void testRemoveOAuthData() {
-    saveThreeFakeOAuthData();
-    dataStore.removeOAuthData("email1@example.com");
-    dataStore.removeOAuthData("email3@example.com");
-
-    assertEquals(1, dataStore.loadOAuthData().size());
-    verifyContains(dataStore.loadOAuthData(), fakeOAuthData[1]);
-  }
-
-  @Test
-  public void testRemoveOAuthData_nonExistingEmail() {
-    saveThreeFakeOAuthData();
-    dataStore.removeOAuthData("email999@example.com");
-
-    Set<OAuthData> loaded = dataStore.loadOAuthData();
-    assertEquals(3, loaded.size());
-    verifyContains(loaded, fakeOAuthData[0]);
-    verifyContains(loaded, fakeOAuthData[1]);
-    verifyContains(loaded, fakeOAuthData[2]);
-  }
-
-  @Test
   public void testSaveLoadOAuthData_nullValues() {
     dataStore.saveOAuthData(new OAuthData(null, null, "email@example.com", null, 0));
     OAuthData loaded = dataStore.loadOAuthData().iterator().next();
@@ -164,6 +131,39 @@ public class JavaPreferenceOAuthDataStoreTest {
     OAuthData oAuthData = new OAuthData(null, null, "email@example.com", scopes, 0);
 
     dataStore.saveOAuthData(oAuthData);
+  }
+
+  @Test
+  public void testSaveLoadOAuthData_multipleCredentials() {
+    saveThreeFakeOAuthData();
+
+    Set<OAuthData> loaded = dataStore.loadOAuthData();
+    assertEquals(3, loaded.size());
+    verifyContains(loaded, fakeOAuthData[0]);
+    verifyContains(loaded, fakeOAuthData[1]);
+    verifyContains(loaded, fakeOAuthData[2]);
+  }
+
+  @Test
+  public void testRemoveOAuthData() {
+    saveThreeFakeOAuthData();
+    dataStore.removeOAuthData("email1@example.com");
+    dataStore.removeOAuthData("email3@example.com");
+
+    assertEquals(1, dataStore.loadOAuthData().size());
+    verifyContains(dataStore.loadOAuthData(), fakeOAuthData[1]);
+  }
+
+  @Test
+  public void testRemoveOAuthData_nonExistingEmail() {
+    saveThreeFakeOAuthData();
+    dataStore.removeOAuthData("email999@example.com");
+
+    Set<OAuthData> loaded = dataStore.loadOAuthData();
+    assertEquals(3, loaded.size());
+    verifyContains(loaded, fakeOAuthData[0]);
+    verifyContains(loaded, fakeOAuthData[1]);
+    verifyContains(loaded, fakeOAuthData[2]);
   }
 
   @After

--- a/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
@@ -89,12 +89,6 @@ public class JavaPreferenceOAuthDataStoreTest {
   }
 
   @Test
-  public void testSaveLoadOAuthData_emptyEmail() {
-    dataStore.saveOAuthData(new OAuthData(null, null, "", null, 0));
-    assertTrue(dataStore.loadOAuthData().isEmpty());
-  }
-
-  @Test
   public void testSaveClearLoadOAuthData() {
     saveThreeFakeOAuthData();
     dataStore.clearStoredOAuthData();
@@ -131,6 +125,12 @@ public class JavaPreferenceOAuthDataStoreTest {
     OAuthData oAuthData = new OAuthData(null, null, "email@example.com", scopes, 0);
 
     dataStore.saveOAuthData(oAuthData);
+  }
+
+  @Test
+  public void testSaveLoadOAuthData_emptyEmail() {
+    dataStore.saveOAuthData(new OAuthData(null, null, "", null, 0));
+    assertTrue(dataStore.loadOAuthData().isEmpty());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
@@ -46,11 +46,12 @@ public class JavaPreferenceOAuthDataStoreTest {
       new OAuthData("accessToken2", "refreshToken2", "email2@example.com", FAKE_OAUTH_SCOPES, 234),
       new OAuthData("accessToken3", "refreshToken3", "email3@example.com", FAKE_OAUTH_SCOPES, 345)
   };
+  public static final String TEST_PREFERENCE_PATH = "some_test_preference_path";
 
   @Mock private LoggerFacade logger;
 
   private JavaPreferenceOAuthDataStore dataStore =
-      new JavaPreferenceOAuthDataStore("some_test_preference_path", logger);
+      new JavaPreferenceOAuthDataStore(TEST_PREFERENCE_PATH, logger);
 
   @Test
   public void testLoadOAuthData_returnEmptyOAuthData() {
@@ -168,7 +169,7 @@ public class JavaPreferenceOAuthDataStoreTest {
   @After
   public void tearDown() throws BackingStoreException {
     dataStore.clearStoredOAuthData();
-    Preferences.userRoot().node("some test preference path").removeNode();
+    Preferences.userRoot().node(TEST_PREFERENCE_PATH).removeNode();
   }
 
   private void saveThreeFakeOAuthData() {

--- a/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
@@ -38,6 +38,8 @@ import java.util.prefs.Preferences;
 @RunWith(MockitoJUnitRunner.class)
 public class JavaPreferenceOAuthDataStoreTest {
 
+  private static final String TEST_PREFERENCE_PATH = "some_test_preference_path";
+
   private static final Set<String> FAKE_OAUTH_SCOPES = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList("my-scope1", "my-scope2")));
 
@@ -46,7 +48,6 @@ public class JavaPreferenceOAuthDataStoreTest {
       new OAuthData("accessToken2", "refreshToken2", "email2@example.com", FAKE_OAUTH_SCOPES, 234),
       new OAuthData("accessToken3", "refreshToken3", "email3@example.com", FAKE_OAUTH_SCOPES, 345)
   };
-  public static final String TEST_PREFERENCE_PATH = "some_test_preference_path";
 
   @Mock private LoggerFacade logger;
 
@@ -181,7 +182,7 @@ public class JavaPreferenceOAuthDataStoreTest {
   private void verifyContains(Set<OAuthData> oAuthDataSet, OAuthData oAuthDataToMatch) {
     for (OAuthData oAuthData : oAuthDataSet) {
       if (Objects.equals(oAuthData.getEmail(), oAuthDataToMatch.getEmail())
-        && Objects.equals(oAuthData.getAccessToken(), oAuthDataToMatch.getAccessToken())
+          && Objects.equals(oAuthData.getAccessToken(), oAuthDataToMatch.getAccessToken())
           && Objects.equals(oAuthData.getRefreshToken(), oAuthDataToMatch.getRefreshToken())
           && Objects.equals(oAuthData.getStoredScopes(), oAuthDataToMatch.getStoredScopes())
           && oAuthData.getAccessTokenExpiryTime() == oAuthDataToMatch.getAccessTokenExpiryTime()) {

--- a/src/test/java/com/google/cloud/tools/ide/login/OAuthDataTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/OAuthDataTest.java
@@ -40,7 +40,7 @@ public class OAuthDataTest {
 
   @Test(expected = NullPointerException.class)
   public void testNullEmail() {
-    data = new OAuthData(null, null, null, null, 10);
+    new OAuthData(null, null, null, null, 10);
   }
 
   @Test

--- a/src/test/java/com/google/cloud/tools/ide/login/OAuthDataTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/OAuthDataTest.java
@@ -68,4 +68,3 @@ public class OAuthDataTest {
     Assert.assertEquals(10L, data.getAccessTokenExpiryTime());
   }
 }
-

--- a/src/test/java/com/google/cloud/tools/ide/login/OAuthDataTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/OAuthDataTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.ide.login;
 
 import com.google.common.collect.ImmutableSet;
@@ -16,16 +32,20 @@ public class OAuthDataTest {
 
   @Test
   public void testNullable() {
-    data = new OAuthData(null, null, null, null, 10);
-    Assert.assertNull(data.getStoredEmail());
+    data = new OAuthData(null, null, "email@example.com", null, 10);
     Assert.assertNull(data.getRefreshToken());
     Assert.assertNull(data.getAccessToken());
     Assert.assertTrue(data.getStoredScopes().isEmpty());
   }
-  
+
+  @Test(expected = NullPointerException.class)
+  public void testNullEmail() {
+    data = new OAuthData(null, null, null, null, 10);
+  }
+
   @Test
-  public void testGetStoredEmail() {
-    Assert.assertEquals("storedEmail@example.com", data.getStoredEmail());
+  public void testGetEmail() {
+    Assert.assertEquals("storedEmail@example.com", data.getEmail());
   }
 
   @Test


### PR DESCRIPTION
Fixes #23.

- Most of the changes are in `JavaPreferenceOAuthDataStore`:
  - Previously, the preference root node recorded an email address with the key `EMAIL`, which could be null.
  - Now, each email address becomes the name of a child node. (Therefore, an email cannot be empty or null.)

- Changes in `GoogleLoginState` are only about doing things in a `for` loop.