### PR TITLE
Fetch/save/load account name and avatar URL

### DIFF
--- a/src/main/java/com/google/cloud/tools/ide/login/Account.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/Account.java
@@ -26,10 +26,10 @@ import javax.annotation.Nullable;
  */
 public class Account {
 
-  private String email;
-  private Credential oAuth2Credential;
-  @Nullable private String name;
-  @Nullable private String avatarUrl;
+  private final String email;
+  private final Credential oAuth2Credential;
+  @Nullable private final String name;
+  @Nullable private final String avatarUrl;
 
   Account(String email, Credential oAuth2Credential,
           @Nullable String name, @Nullable String avatarUrl) {

--- a/src/main/java/com/google/cloud/tools/ide/login/Account.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/Account.java
@@ -20,7 +20,6 @@ import com.google.api.client.auth.oauth2.Credential;
 import com.google.common.base.Preconditions;
 
 import javax.annotation.Nullable;
-import java.net.URL;
 
 /**
  * Represents a single logged-in account.
@@ -30,14 +29,17 @@ public class Account {
   private String email;
   private Credential oAuth2Credential;
   @Nullable private String name;
-  @Nullable private URL avatarUrl;
+  @Nullable private String avatarUrl;
 
-  Account(String email, Credential oAuth2Credential) {
+  Account(String email, Credential oAuth2Credential,
+          @Nullable String name, @Nullable String avatarUrl) {
     Preconditions.checkNotNull(email);
     Preconditions.checkNotNull(oAuth2Credential);
 
     this.email = email;
     this.oAuth2Credential = oAuth2Credential;
+    this.name = name;
+    this.avatarUrl = avatarUrl;
   }
 
   public String getEmail() {
@@ -50,7 +52,7 @@ public class Account {
   }
 
   @Nullable
-  public URL getAvatarUrl() {
+  public String getAvatarUrl() {
     return avatarUrl;
   }
 

--- a/src/main/java/com/google/cloud/tools/ide/login/AccountRoster.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/AccountRoster.java
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 class AccountRoster {
 
-  private Set<Account> accounts = new HashSet<>();
+  private final Set<Account> accounts = new HashSet<>();
 
   void clear() {
     accounts.clear();

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleAuthorizationCodeTokenRequestCreator.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleAuthorizationCodeTokenRequestCreator.java
@@ -21,7 +21,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.common.annotations.VisibleForTesting;
 
-/** Wrapper for the GoogleAuthorizationCodeTokenRequest constructor. Only for unit-testing. */
+/** Wrapper for the GoogleAuthorizationCodeTokenRequest constructor. Only for unit testing. */
 @VisibleForTesting
 class GoogleAuthorizationCodeTokenRequestCreator {
 

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleAuthorizationCodeTokenRequestCreator.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleAuthorizationCodeTokenRequestCreator.java
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.tools.ide.login;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeTokenRequest;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.repackaged.com.google.common.annotations.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 
 /**
  * Wrapper for the GoogleAuthorizationCodeTokenRequest constructor. Only for unit-testing.

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
@@ -351,7 +351,7 @@ public class GoogleLoginState {
 
   @VisibleForTesting
   static class EmailAddressNotReturnedException extends Exception {
-    public EmailAddressNotReturnedException(String message) {
+    private EmailAddressNotReturnedException(String message) {
       super(message);
     }
   };

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
@@ -350,7 +350,7 @@ public class GoogleLoginState {
   }
 
   @VisibleForTesting
-  class EmailAddressNotReturnedException extends Exception {
+  static class EmailAddressNotReturnedException extends Exception {
     public EmailAddressNotReturnedException(String message) {
       super(message);
     }

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
@@ -94,7 +94,7 @@ public class GoogleLoginState {
   public GoogleLoginState(String clientId, String clientSecret, Set<String> oAuthScopes,
       OAuthDataStore authDataStore, UiFacade uiFacade, LoggerFacade loggerFacade) {
     this(clientId, clientSecret, oAuthScopes, authDataStore, uiFacade, loggerFacade,
-      new GoogleAuthorizationCodeTokenRequestCreator(), new UserInfoService());
+        new GoogleAuthorizationCodeTokenRequestCreator(), new UserInfoService());
   }
 
   @VisibleForTesting

--- a/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/GoogleLoginState.java
@@ -270,7 +270,7 @@ public class GoogleLoginState {
   private Account updateLoginState(GoogleTokenResponse tokenResponse)
       throws IOException, EmailAddressNotReturnedException {
     Credential credential = buildCredential().setFromTokenResponse(tokenResponse);
-    UserInfoService.UserInfo userInfo = queryUserInfo(credential);
+    UserInfo userInfo = queryUserInfo(credential);
     accountRoster.addAccount(
         new Account(userInfo.getEmail(), credential, userInfo.getName(), userInfo.getPicture()));
 
@@ -313,7 +313,7 @@ public class GoogleLoginState {
   }
 
   @VisibleForTesting
-  UserInfoService.UserInfo queryUserInfo(Credential credential)
+  UserInfo queryUserInfo(Credential credential)
       throws IOException, EmailAddressNotReturnedException {
     HttpRequestInitializer timeoutSetter = new HttpRequestInitializer() {
       @Override
@@ -323,7 +323,7 @@ public class GoogleLoginState {
       }
     };
 
-    UserInfoService.UserInfo userInfo = userInfoService.buildAndExecuteRequest(
+    UserInfo userInfo = userInfoService.buildAndExecuteRequest(
         transport, jsonFactory, credential, timeoutSetter);
     if (userInfo == null || Strings.isNullOrEmpty(userInfo.getEmail())) {
       throw new EmailAddressNotReturnedException("Server failed to return email address");

--- a/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
@@ -41,6 +41,8 @@ public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
   private static final String KEY_ACCESS_TOKEN = "access_token";
   private static final String KEY_REFRESH_TOKEN = "refresh_token";
   private static final String KEY_ACCESS_TOKEN_EXPIRY_TIME = "access_token_expiry_time";
+  private static final String KEY_ACCOUNT_NAME = "account_name";
+  private static final String KEY_AVATAR_URL = "avatar_url";
   private static final String KEY_OAUTH_SCOPES = "oauth_scopes";
 
   @VisibleForTesting
@@ -80,6 +82,8 @@ public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
     accountNode.put(KEY_ACCESS_TOKEN, Strings.nullToEmpty(oAuthData.getAccessToken()));
     accountNode.put(KEY_REFRESH_TOKEN, Strings.nullToEmpty(oAuthData.getRefreshToken()));
     accountNode.putLong(KEY_ACCESS_TOKEN_EXPIRY_TIME, oAuthData.getAccessTokenExpiryTime());
+    accountNode.put(KEY_ACCOUNT_NAME, Strings.nullToEmpty(oAuthData.getName()));
+    accountNode.put(KEY_AVATAR_URL, Strings.nullToEmpty(oAuthData.getAvatarUrl()));
     accountNode.put(KEY_OAUTH_SCOPES, Joiner.on(SCOPE_DELIMITER).join(oAuthData.getStoredScopes()));
 
     try {
@@ -101,13 +105,15 @@ public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
         String accessToken = Strings.emptyToNull(accountNode.get(KEY_ACCESS_TOKEN, null));
         String refreshToken = Strings.emptyToNull(accountNode.get(KEY_REFRESH_TOKEN, null));
         long accessTokenExpiryTime = accountNode.getLong(KEY_ACCESS_TOKEN_EXPIRY_TIME, 0);
+        String name = Strings.emptyToNull(accountNode.get(KEY_ACCOUNT_NAME, null));
+        String avatarUrl = Strings.emptyToNull(accountNode.get(KEY_AVATAR_URL, null));
         String scopesString = accountNode.get(KEY_OAUTH_SCOPES, "");
 
         Set<String> oAuthScopes = new HashSet<>(
             Splitter.on(SCOPE_DELIMITER).omitEmptyStrings().splitToList(scopesString));
 
-        oAuthDataSet.add(
-            new OAuthData(accessToken, refreshToken, email, oAuthScopes, accessTokenExpiryTime));
+        oAuthDataSet.add(new OAuthData(
+            accessToken, refreshToken, email, name, avatarUrl, oAuthScopes, accessTokenExpiryTime));
       }
     } catch (BackingStoreException bse) {
       logger.logWarning("Could not flush preferences: " + bse.getMessage());

--- a/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStore.java
@@ -35,8 +35,8 @@ import java.util.prefs.Preferences;
  */
 public class JavaPreferenceOAuthDataStore implements OAuthDataStore {
 
-  private String preferencePath;
-  private LoggerFacade logger;
+  private final String preferencePath;
+  private final LoggerFacade logger;
 
   private static final String KEY_ACCESS_TOKEN = "access_token";
   private static final String KEY_REFRESH_TOKEN = "refresh_token";

--- a/src/main/java/com/google/cloud/tools/ide/login/OAuthData.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/OAuthData.java
@@ -34,6 +34,8 @@ public class OAuthData {
   private final String email;
   @Nullable private final String accessToken;
   @Nullable private final String refreshToken;
+  @Nullable private final String name;
+  @Nullable private final String avatarUrl;
   private final long accessTokenExpiryTime;
   private final Set<String> storedScopes;
 
@@ -41,18 +43,31 @@ public class OAuthData {
    * @param scopes if null, an empty set will be created and set
    */
   public OAuthData(@Nullable String accessToken, @Nullable String refreshToken, String email,
+      @Nullable String name, @Nullable String avatarUrl,
       @Nullable Set<String> scopes, long accessTokenExpiryTime) {
     Preconditions.checkNotNull(email);
 
     this.accessToken = accessToken;
     this.refreshToken = refreshToken;
     this.email = email;
+    this.name = name;
+    this.avatarUrl = avatarUrl;
     this.storedScopes = (scopes == null ? ImmutableSet.<String>of() : scopes);
     this.accessTokenExpiryTime = accessTokenExpiryTime;
   }
 
   public String getEmail() {
     return email;
+  }
+
+  @Nullable
+  public String getName() {
+    return name;
+  }
+
+  @Nullable
+  public String getAvatarUrl() {
+    return avatarUrl;
   }
 
   public Set<String> getStoredScopes() {

--- a/src/main/java/com/google/cloud/tools/ide/login/UserInfo.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/UserInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.ide.login;
+
+import com.google.api.services.oauth2.model.Userinfoplus;
+import com.google.common.annotations.VisibleForTesting;
+
+/** A wrapper for {@link Userinfoplus} to enable unit testing. */
+@VisibleForTesting
+class UserInfo {
+
+  private final Userinfoplus userInfoPlus;
+
+  UserInfo(Userinfoplus userInfoPlus) {
+    this.userInfoPlus = userInfoPlus;
+  }
+
+  String getEmail() {
+    return userInfoPlus.getEmail();
+  }
+
+  String getName() {
+    return userInfoPlus.getName();
+  }
+
+  String getPicture() {
+    return userInfoPlus.getPicture();
+  }
+}

--- a/src/main/java/com/google/cloud/tools/ide/login/UserInfoService.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/UserInfoService.java
@@ -58,27 +58,4 @@ class UserInfoService {
     }
     return new UserInfo(userInfoPlus);
   }
-
-  /** A wrapper for {@link Userinfoplus} to enable unit testing. */
-  @VisibleForTesting
-  class UserInfo {
-
-    private Userinfoplus userInfoPlus;
-
-    UserInfo(Userinfoplus userInfoPlus) {
-      this.userInfoPlus = userInfoPlus;
-    }
-
-    String getEmail() {
-      return userInfoPlus.getEmail();
-    }
-
-    String getName() {
-      return userInfoPlus.getName();
-    }
-
-    String getPicture() {
-      return userInfoPlus.getPicture();
-    }
-  }
 }

--- a/src/main/java/com/google/cloud/tools/ide/login/UserInfoService.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/UserInfoService.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.ide.login;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.repackaged.com.google.common.base.Preconditions;
+import com.google.api.services.oauth2.Oauth2;
+import com.google.api.services.oauth2.model.Userinfoplus;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.io.IOException;
+
+/**
+ * A wrapper around {@link Oauth2.Builder}, {@link Oauth2}, and {@link Userinfoplus} to enable
+ * unit testing, since Mockito cannot mock {@code final} classes. ({@link Oauth2.Builder} and
+ * {@link Userinfoplus} are {@code final}.)
+ */
+@VisibleForTesting
+class UserInfoService {
+
+  UserInfo buildAndExecuteRequest(HttpTransport httpTransport, JsonFactory jsonFactory,
+      final Credential credential, final HttpRequestInitializer additionalInitializer)
+      throws IOException {
+
+    // Chain the credential's initializer and the additional initializer.
+    HttpRequestInitializer chainedInitializer = new HttpRequestInitializer() {
+      @Override
+      public void initialize(HttpRequest httpRequest) throws IOException {
+        credential.getRequestInitializer().initialize(httpRequest);
+        additionalInitializer.initialize(httpRequest);
+      }
+    };
+
+    Oauth2 oauth2 = new Oauth2.Builder(httpTransport, jsonFactory, credential)
+        .setHttpRequestInitializer(chainedInitializer)
+        .build();
+
+    Userinfoplus userInfoPlus = oauth2.userinfo().get().execute();
+    if (userInfoPlus == null) {
+      return null;
+    }
+    return new UserInfo(userInfoPlus);
+  }
+
+  /**
+   * A wrapper for {@link Userinfoplus} to enable unit testing.
+   */
+  @VisibleForTesting
+  class UserInfo {
+
+    private Userinfoplus userInfoPlus;
+
+    UserInfo(Userinfoplus userInfoPlus) {
+      this.userInfoPlus = userInfoPlus;
+    }
+
+    String getEmail() {
+      return userInfoPlus.getEmail();
+    }
+
+    String getName() {
+      return userInfoPlus.getName();
+    }
+
+    String getPicture() {
+      return userInfoPlus.getPicture();
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/tools/ide/login/UserInfoService.java
+++ b/src/main/java/com/google/cloud/tools/ide/login/UserInfoService.java
@@ -49,11 +49,11 @@ class UserInfoService {
       }
     };
 
-    Oauth2 oauth2 = new Oauth2.Builder(httpTransport, jsonFactory, credential)
+    Oauth2 oAuth2 = new Oauth2.Builder(httpTransport, jsonFactory, credential)
         .setHttpRequestInitializer(chainedInitializer)
         .build();
 
-    Userinfoplus userInfoPlus = oauth2.userinfo().get().execute();
+    Userinfoplus userInfoPlus = oAuth2.userinfo().get().execute();
     if (userInfoPlus == null) {
       return null;
     }

--- a/src/test/java/com/google/cloud/tools/ide/login/AccountRosterTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/AccountRosterTest.java
@@ -34,7 +34,9 @@ public class AccountRosterTest {
   private static final Account[] fakeAccounts = new Account[] {
     new Account("email-1@example.com", mock(Credential.class), "name1", "avatar-url1"),
     new Account("email-2@example.com", mock(Credential.class), "name2", "avatar-url2"),
-    new Account("email-3@example.com", mock(Credential.class), "name3", "avatar-url3")
+    new Account("email-3@example.com", mock(Credential.class), "name3", "avatar-url3"),
+    new Account("email-4@example.com", mock(Credential.class), null, "avatar-url4"),
+    new Account("email-5@example.com", mock(Credential.class), "name5", null)
   };
 
   @Test(expected = NullPointerException.class)
@@ -71,10 +73,12 @@ public class AccountRosterTest {
     addAllFakeAccounts();
 
     Set<Account> accounts = accountRoster.getAccounts();
-    assertEquals(3, accounts.size());
+    assertEquals(5, accounts.size());
     assertTrue(accounts.contains(fakeAccounts[0]));
     assertTrue(accounts.contains(fakeAccounts[1]));
     assertTrue(accounts.contains(fakeAccounts[2]));
+    assertTrue(accounts.contains(fakeAccounts[3]));
+    assertTrue(accounts.contains(fakeAccounts[4]));
   }
 
   @Test
@@ -82,7 +86,7 @@ public class AccountRosterTest {
     addAllFakeAccounts();
 
     Set<Account> accounts = accountRoster.getAccounts();
-    assertEquals(3, accounts.size());
+    assertEquals(5, accounts.size());
     assertTrue(accounts.contains(fakeAccounts[2]));
 
     Account sameEmailAccount = new Account(
@@ -90,7 +94,7 @@ public class AccountRosterTest {
     accountRoster.addAccount(sameEmailAccount);
 
     accounts = accountRoster.getAccounts();
-    assertEquals(3, accounts.size());
+    assertEquals(5, accounts.size());
     for (Account account : accounts) {
       assertFalse(account == fakeAccounts[2]);
     }
@@ -108,5 +112,7 @@ public class AccountRosterTest {
     accountRoster.addAccount(fakeAccounts[0]);
     accountRoster.addAccount(fakeAccounts[1]);
     accountRoster.addAccount(fakeAccounts[2]);
+    accountRoster.addAccount(fakeAccounts[3]);
+    accountRoster.addAccount(fakeAccounts[4]);
   }
 }

--- a/src/test/java/com/google/cloud/tools/ide/login/AccountRosterTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/AccountRosterTest.java
@@ -32,19 +32,19 @@ public class AccountRosterTest {
   private AccountRoster accountRoster = new AccountRoster();
 
   private static final Account[] fakeAccounts = new Account[] {
-    new Account("email-1@example.com", mock(Credential.class)),
-    new Account("email-2@example.com", mock(Credential.class)),
-    new Account("email-3@example.com", mock(Credential.class))
+    new Account("email-1@example.com", mock(Credential.class), "name1", "avatar-url1"),
+    new Account("email-2@example.com", mock(Credential.class), "name2", "avatar-url2"),
+    new Account("email-3@example.com", mock(Credential.class), "name3", "avatar-url3")
   };
 
   @Test(expected = NullPointerException.class)
   public void testAddAccount_checkEmailIsNotNull() {
-    accountRoster.addAccount(new Account(null, mock(Credential.class)));
+    accountRoster.addAccount(new Account(null, mock(Credential.class), "name", "avatar-url"));
   }
 
   @Test(expected = NullPointerException.class)
   public void testAddAccount_checkCredentialIsNotNull() {
-    accountRoster.addAccount(new Account("email@example.com", null));
+    accountRoster.addAccount(new Account("email@example.com", null, "name", "avatar-url"));
   }
 
   @Test
@@ -85,7 +85,8 @@ public class AccountRosterTest {
     assertEquals(3, accounts.size());
     assertTrue(accounts.contains(fakeAccounts[2]));
 
-    Account sameEmailAccount = new Account("email-3@example.com", mock(Credential.class));
+    Account sameEmailAccount = new Account(
+        "email-3@example.com", mock(Credential.class), "new-name", "new-avatar-url");
     accountRoster.addAccount(sameEmailAccount);
 
     accounts = accountRoster.getAccounts();

--- a/src/test/java/com/google/cloud/tools/ide/login/AccountTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/AccountTest.java
@@ -31,21 +31,21 @@ public class AccountTest {
 
   @Test
   public void testEquals_compareNull() {
-    Account account = new Account("email@google.com", mock(Credential.class));
+    Account account = new Account("email@google.com", mock(Credential.class), null, null);
     assertFalse(account.equals(null));
   }
 
   @Test
   public void testEquals_wrongType() {
-    Account account = new Account("email@google.com", mock(Credential.class));
+    Account account = new Account("email@google.com", mock(Credential.class), null, null);
     assertFalse(account.equals("email@google.com"));
   }
 
   @Test
   public void testEquals_differentEmails() {
     Credential credential = newCredential("access-token-1", "refresh-token-1", 123);
-    Account account1 = new Account("email-1@google.com", credential);
-    Account account2 = new Account("email-2@google.com", credential);
+    Account account1 = new Account("email-1@google.com", credential, null, null);
+    Account account2 = new Account("email-2@google.com", credential, null, null);
     assertFalse(account1.equals(account2));
   }
 
@@ -54,17 +54,17 @@ public class AccountTest {
     Credential credential1 = newCredential("access-token-1", "refresh-token-1", 123);
     Credential credential2 = newCredential("access-token-2", "refresh-token-2", 456);
 
-    Account account1 = new Account("email@google.com", credential1);
-    Account account2 = new Account("email@google.com", credential2);
+    Account account1 = new Account("email@google.com", credential1, "name1", "avatar-url1");
+    Account account2 = new Account("email@google.com", credential2, "name2", "avatar-url2");
     assertTrue(account1.equals(account2));
   }
 
   @Test
   public void testHashCode() {
-    Account account1 = new Account("email@google.com", mock(Credential.class));
+    Account account1 = new Account("email@google.com", mock(Credential.class), "name", "url");
     assertEquals("email@google.com".hashCode(), account1.hashCode());
 
-    Account account2 = new Account("some string", mock(Credential.class));
+    Account account2 = new Account("some string", mock(Credential.class), "some name", "some url");
     assertEquals("some string".hashCode(), account2.hashCode());
   }
 

--- a/src/test/java/com/google/cloud/tools/ide/login/GoogleLoginStateTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/GoogleLoginStateTest.java
@@ -63,7 +63,7 @@ public class GoogleLoginStateTest {
   @Mock private GoogleAuthorizationCodeTokenRequestCreator authorizationCodeTokenRequestCreator;
   @Mock private UserInfoService userInfoService;
 
-  private OAuthDataStore authDataStore =
+  private final OAuthDataStore authDataStore =
       new JavaPreferenceOAuthDataStore("test-node", mock(LoggerFacade.class));
 
   @Before
@@ -284,7 +284,7 @@ public class GoogleLoginStateTest {
   @Test
   public void testQueryUserInfo() throws IOException, EmailAddressNotReturnedException {
     GoogleLoginState state = newGoogleLoginState();
-    UserInfoService.UserInfo userInfo = state.queryUserInfo(mock(Credential.class));
+    UserInfo userInfo = state.queryUserInfo(mock(Credential.class));
     assertEquals("email-from-server-1@example.com", userInfo.getEmail());
     assertEquals("account-name-1", userInfo.getName());
     assertEquals("http://example.com/image-1", userInfo.getPicture());
@@ -388,17 +388,17 @@ public class GoogleLoginStateTest {
   }
 
   private void mockUserInfoService() throws IOException {
-    UserInfoService.UserInfo userInfo1 = mock(UserInfoService.UserInfo.class);
+    UserInfo userInfo1 = mock(UserInfo.class);
     when(userInfo1.getEmail()).thenReturn("email-from-server-1@example.com");
     when(userInfo1.getName()).thenReturn("account-name-1");
     when(userInfo1.getPicture()).thenReturn("http://example.com/image-1");
 
-    UserInfoService.UserInfo userInfo2 = mock(UserInfoService.UserInfo.class);
+    UserInfo userInfo2 = mock(UserInfo.class);
     when(userInfo2.getEmail()).thenReturn("email-from-server-2@example.com");
     when(userInfo2.getName()).thenReturn("account-name-2");
     when(userInfo2.getPicture()).thenReturn("http://example.com/image-2");
 
-    UserInfoService.UserInfo userInfo3 = mock(UserInfoService.UserInfo.class);
+    UserInfo userInfo3 = mock(UserInfo.class);
     when(userInfo3.getEmail()).thenReturn("email-from-server-3@example.com");
     when(userInfo3.getName()).thenReturn("account-name-3");
     when(userInfo3.getPicture()).thenReturn("http://example.com/image-3");
@@ -419,7 +419,7 @@ public class GoogleLoginStateTest {
   }
 
   private void mockUserInfoServiceReturningNullEmail() throws IOException {
-    UserInfoService.UserInfo userInfo = mock(UserInfoService.UserInfo.class);
+    UserInfo userInfo = mock(UserInfo.class);
     when(userInfo.getEmail()).thenReturn(null);
     when(userInfo.getName()).thenReturn("account-name-1");
     when(userInfo.getPicture()).thenReturn("http://example.com/image-1");

--- a/src/test/java/com/google/cloud/tools/ide/login/GoogleLoginStateTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/GoogleLoginStateTest.java
@@ -28,69 +28,59 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeTokenRequest;
 import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
+import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import org.junit.After;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 
-@RunWith(MockitoJUnitRunner.class)
 public class GoogleLoginStateTest {
 
   private static final Set<String> FAKE_OAUTH_SCOPES = Collections.unmodifiableSet(
       new HashSet<>(Arrays.asList("oauth-scope-1", "oauth-scope-2")));
 
   private static final OAuthData[] fakeOAuthDataList = new OAuthData[] {
-      new OAuthData("accessToken5", "refreshToken5", "email5@example.com", FAKE_OAUTH_SCOPES, 543),
-      new OAuthData("accessToken6", "refreshToken6", "email6@example.com", FAKE_OAUTH_SCOPES, 654),
-      new OAuthData("accessToken7", "refreshToken7", "email7@example.com", FAKE_OAUTH_SCOPES, 765),
+      new OAuthData("accessToken5", "refreshToken5", "email5@example.com",
+                    "accountName5", "http://example.com/image5", FAKE_OAUTH_SCOPES, 543),
+      new OAuthData("accessToken6", "refreshToken6", "email6@example.com",
+                    "accountName6", "http://example.com/image6", FAKE_OAUTH_SCOPES, 654),
+      new OAuthData("accessToken7", "refreshToken7", "email7@example.com",
+                    "accountName7", "http://example.com/image7", FAKE_OAUTH_SCOPES, 765)
   };
 
-  @Mock private GoogleAuthorizationCodeTokenRequestCreator tokenRequestCreator;
-  @Mock private UiFacade uiFacade;
-  @Mock private LoggerFacade loggerFacade;
-
   private OAuthDataStore authDataStore =
-      new JavaPreferenceOAuthDataStore("test-node", loggerFacade);
-
-  private ServerSocket emailServerSocket;
+      new JavaPreferenceOAuthDataStore("test-node", mock(LoggerFacade.class));
 
   @Test
   public void testIsLoggedIn() throws IOException {
-    GoogleLoginState state = newGoogleLoginState(null /* emailQueryUrl */);
+    GoogleLoginState state = newGoogleLoginState();
     assertFalse(state.isLoggedIn());
   }
 
   @Test
   public void testListAccounts() throws IOException {
-    GoogleLoginState state = newGoogleLoginState(null /* emailQueryUrl */);
-    assertEquals(0, state.listAccounts().size());
+    GoogleLoginState state = newGoogleLoginState();
+    assertTrue(state.listAccounts().isEmpty());
   }
 
   @Test
   public void testLoadPersistedAccount() throws IOException {
     authDataStore.saveOAuthData(fakeOAuthDataList[0]);
 
-    GoogleLoginState state = newGoogleLoginState(null /* emailQueryUrl */);
+    GoogleLoginState state = newGoogleLoginState();
 
     assertTrue(state.isLoggedIn());
     Set<Account> accounts = state.listAccounts();
     assertEquals(1, accounts.size());
-    verifyAccountsContain(accounts, "email5@example.com", "accessToken5", "refreshToken5", 543);
+    verifyAccountsContain(accounts, "email5@example.com", "accessToken5", "refreshToken5", 543,
+        "accountName5", "http://example.com/image5");
   }
 
   @Test
@@ -99,24 +89,27 @@ public class GoogleLoginStateTest {
     authDataStore.saveOAuthData(fakeOAuthDataList[1]);
     authDataStore.saveOAuthData(fakeOAuthDataList[2]);
 
-    GoogleLoginState state = newGoogleLoginState(null /* emailQueryUrl */);
+    GoogleLoginState state = newGoogleLoginState();
 
     assertTrue(state.isLoggedIn());
     Set<Account> accounts = state.listAccounts();
     assertEquals(3, accounts.size());
-    verifyAccountsContain(accounts, "email5@example.com", "accessToken5", "refreshToken5", 543);
-    verifyAccountsContain(accounts, "email6@example.com", "accessToken6", "refreshToken6", 654);
-    verifyAccountsContain(accounts, "email7@example.com", "accessToken7", "refreshToken7", 765);
+    verifyAccountsContain(accounts, "email5@example.com", "accessToken5", "refreshToken5", 543,
+        "accountName5", "http://example.com/image5");
+    verifyAccountsContain(accounts, "email6@example.com", "accessToken6", "refreshToken6", 654,
+        "accountName6", "http://example.com/image6");
+    verifyAccountsContain(accounts, "email7@example.com", "accessToken7", "refreshToken7", 765,
+        "accountName7", "http://example.com/image7");
   }
 
   @Test
   public void testLoadPersistedAccount_removeCredentialIfScopesMismatch() throws IOException {
     Set<String> deprecatedScopes = new HashSet<>(Arrays.asList("deprecated-scope"));
-    OAuthData invalidatedOAuthData = new OAuthData(
-        "access-token-1", "refresh-token-1", "email-1@example.com", deprecatedScopes, 0);
+    OAuthData invalidatedOAuthData = new OAuthData("access-token-1", "refresh-token-1",
+        "email-1@example.com", "name-1", "avatar-url-1", deprecatedScopes, 0);
     authDataStore.saveOAuthData(invalidatedOAuthData);
 
-    GoogleLoginState state = newGoogleLoginState(null /* emailQueryUrl */);
+    GoogleLoginState state = newGoogleLoginState();
 
     assertFalse(state.isLoggedIn());
     assertTrue(state.listAccounts().isEmpty());
@@ -125,8 +118,8 @@ public class GoogleLoginStateTest {
   @Test
   public void testLoadPersistedAccounts_removeCredentialsIfScopesMismatch() throws IOException {
     Set<String> deprecatedScopes = new HashSet<>(Arrays.asList("deprecated-scope"));
-    OAuthData invalidatedOAuthData = new OAuthData(
-        "access-token-1", "refresh-token-1", "email-1@example.com", deprecatedScopes, 0);
+    OAuthData invalidatedOAuthData = new OAuthData("access-token-1", "refresh-token-1",
+        "email-1@example.com", "name-1", "avatar-url-1", deprecatedScopes, 0);
     authDataStore.saveOAuthData(fakeOAuthDataList[0]);
     authDataStore.saveOAuthData(invalidatedOAuthData);
     authDataStore.saveOAuthData(fakeOAuthDataList[1]);
@@ -134,67 +127,75 @@ public class GoogleLoginStateTest {
     authDataStore.saveOAuthData(fakeOAuthDataList[2]);
     authDataStore.saveOAuthData(invalidatedOAuthData);
 
-    GoogleLoginState state = newGoogleLoginState(null /* emailQueryUrl */);
+    GoogleLoginState state = newGoogleLoginState();
 
     assertTrue(state.isLoggedIn());
     Set<Account> accounts = state.listAccounts();
     assertEquals(3, accounts.size());
-    verifyAccountsContain(accounts, "email5@example.com", "accessToken5", "refreshToken5", 543);
-    verifyAccountsContain(accounts, "email6@example.com", "accessToken6", "refreshToken6", 654);
-    verifyAccountsContain(accounts, "email7@example.com", "accessToken7", "refreshToken7", 765);
+    verifyAccountsContain(accounts, "email5@example.com", "accessToken5", "refreshToken5", 543,
+        "accountName5", "http://example.com/image5");
+    verifyAccountsContain(accounts, "email6@example.com", "accessToken6", "refreshToken6", 654,
+        "accountName6", "http://example.com/image6");
+    verifyAccountsContain(accounts, "email7@example.com", "accessToken7", "refreshToken7", 765,
+        "accountName7", "http://example.com/image7");
   }
 
   @Test
   public void testLogInWithLocalServer() throws IOException {
-    String emailQueryUrl = runEmailQueryServer(1, EmailServerResponse.OK);
-    GoogleLoginState state = newGoogleLoginState(emailQueryUrl);
+    GoogleLoginState state = newGoogleLoginState();
 
     long currentTime = System.currentTimeMillis();
     Account account1 = state.logInWithLocalServer(null /* no title */);
 
     assertTrue(state.isLoggedIn());
     verifyAccountEquals(account1,
-        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1);
+        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1,
+        "account-name-1", "http://example.com/image-1");
     assertTrue(currentTime + 100 * 1000 <= account1.getAccessTokenExpiryTime());
     assertTrue(currentTime + 105 * 1000 > account1.getAccessTokenExpiryTime());
 
     Account account2 = state.listAccounts().iterator().next();
     verifyAccountEquals(account2,
-        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1);
+        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1,
+        "account-name-1", "http://example.com/image-1");
     assertTrue(currentTime + 100 * 1000 <= account2.getAccessTokenExpiryTime());
     assertTrue(currentTime + 105 * 1000 > account2.getAccessTokenExpiryTime());
   }
 
   @Test
   public void testLogInWithLocalServer_threeLogins() throws IOException {
-    String emailQueryUrl = runEmailQueryServer(3, EmailServerResponse.OK);
-    GoogleLoginState state = newGoogleLoginState(emailQueryUrl);
+    GoogleLoginState state = newGoogleLoginState();
 
     Account account1 = state.logInWithLocalServer(null /* no title */);
     Account account2 = state.logInWithLocalServer(null);
     Account account3 = state.logInWithLocalServer(null);
 
     verifyAccountEquals(account1,
-        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1);
+        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1,
+        "account-name-1", "http://example.com/image-1");
     verifyAccountEquals(account2,
-        "email-from-server-2@example.com", "access-token-login-2", "refresh-token-login-2", -1);
+        "email-from-server-2@example.com", "access-token-login-2", "refresh-token-login-2", -1,
+        "account-name-2", "http://example.com/image-2");
     verifyAccountEquals(account3,
-        "email-from-server-3@example.com", "access-token-login-3", "refresh-token-login-3", -1);
+        "email-from-server-3@example.com", "access-token-login-3", "refresh-token-login-3", -1,
+        "account-name-3", "http://example.com/image-3");
 
     Set<Account> accounts = state.listAccounts();
     assertEquals(3, accounts.size());
     verifyAccountsContain(accounts,
-        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1);
+        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1,
+        "account-name-1", "http://example.com/image-1");
     verifyAccountsContain(accounts,
-        "email-from-server-2@example.com", "access-token-login-2", "refresh-token-login-2", -1);
+        "email-from-server-2@example.com", "access-token-login-2", "refresh-token-login-2", -1,
+        "account-name-2", "http://example.com/image-2");
     verifyAccountsContain(accounts,
-        "email-from-server-3@example.com", "access-token-login-3", "refresh-token-login-3", -1);
+        "email-from-server-3@example.com", "access-token-login-3", "refresh-token-login-3", -1,
+        "account-name-3", "http://example.com/image-3");
   }
 
   @Test
   public void testLogOutAll() throws IOException {
-    String emailQueryUrl = runEmailQueryServer(3, EmailServerResponse.OK);
-    GoogleLoginState state = newGoogleLoginState(emailQueryUrl);
+    GoogleLoginState state = newGoogleLoginState();
 
     state.logInWithLocalServer(null /* no title */);
     state.logInWithLocalServer(null);
@@ -206,13 +207,12 @@ public class GoogleLoginStateTest {
     state.logOutAll(false /* don't show prompt dialog */);
 
     assertFalse(state.isLoggedIn());
-    assertEquals(0, state.listAccounts().size());
+    assertTrue(state.listAccounts().isEmpty());
   }
 
   @Test
   public void testListAccounts_isSnapshot() throws IOException {
-    String emailQueryUrl = runEmailQueryServer(1, EmailServerResponse.OK);
-    GoogleLoginState state = newGoogleLoginState(emailQueryUrl);
+    GoogleLoginState state = newGoogleLoginState();
 
     state.logInWithLocalServer(null /* no title */);
 
@@ -229,78 +229,129 @@ public class GoogleLoginStateTest {
 
   @Test
   public void testPersistLoadAccount() throws IOException {
-    String emailQueryUrl = runEmailQueryServer(1, EmailServerResponse.OK);
-    GoogleLoginState state1 = newGoogleLoginState(emailQueryUrl);
+    GoogleLoginState state1 = newGoogleLoginState();
     state1.logInWithLocalServer(null);  // Credentials will be persisted in authDataStore.
 
-    GoogleLoginState state2 = newGoogleLoginState(null /* emailQueryUrl */);
+    GoogleLoginState state2 = newGoogleLoginState();
     assertTrue(state2.isLoggedIn());
     assertEquals(1, state2.listAccounts().size());
     verifyAccountsContain(state2.listAccounts(),
-        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1);
+        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1,
+        "account-name-1", "http://example.com/image-1");
   }
 
   @Test
   public void testPersistLoadAccounts() throws IOException {
-    String emailQueryUrl = runEmailQueryServer(3, EmailServerResponse.OK);
-    GoogleLoginState state1 = newGoogleLoginState(emailQueryUrl);
+    GoogleLoginState state1 = newGoogleLoginState();
     state1.logInWithLocalServer(null);  // Credentials will be persisted in authDataStore.
     state1.logInWithLocalServer(null);
     state1.logInWithLocalServer(null);
 
-    GoogleLoginState state2 = newGoogleLoginState(null /* emailQueryUrl */);
+    GoogleLoginState state2 = newGoogleLoginState();
     assertTrue(state2.isLoggedIn());
     Set<Account> accounts = state2.listAccounts();
     assertEquals(3, accounts.size());
     verifyAccountsContain(accounts,
-        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1);
+        "email-from-server-1@example.com", "access-token-login-1", "refresh-token-login-1", -1,
+        "account-name-1", "http://example.com/image-1");
     verifyAccountsContain(accounts,
-        "email-from-server-2@example.com", "access-token-login-2", "refresh-token-login-2", -1);
+        "email-from-server-2@example.com", "access-token-login-2", "refresh-token-login-2", -1,
+        "account-name-2", "http://example.com/image-2");
     verifyAccountsContain(accounts,
-        "email-from-server-3@example.com", "access-token-login-3", "refresh-token-login-3", -1);
+        "email-from-server-3@example.com", "access-token-login-3", "refresh-token-login-3", -1,
+        "account-name-3", "http://example.com/image-3");
   }
 
   @Test
-  public void testQueryEmail()
+  public void testQueryUserInfo()
       throws IOException, GoogleLoginState.EmailAddressNotReturnedException {
-    String emailQueryUrl = runEmailQueryServer(1, EmailServerResponse.OK);
-    GoogleLoginState state = newGoogleLoginState(emailQueryUrl);
-    assertEquals("email-from-server-1@example.com", state.queryEmail(null));
+    GoogleLoginState state = newGoogleLoginState();
+    UserInfoService.UserInfo userInfo = state.queryUserInfo(mock(Credential.class));
+    assertEquals("email-from-server-1@example.com", userInfo.getEmail());
+    assertEquals("account-name-1", userInfo.getName());
+    assertEquals("http://example.com/image-1", userInfo.getPicture());
   }
 
   @Test(expected = IOException.class)
-  public void testQueryEmail_internalServerError()
+  public void testQueryUserInfo_IOExceptionInUserInfoRequest()
       throws IOException, GoogleLoginState.EmailAddressNotReturnedException {
-    String emailQueryUrl = runEmailQueryServer(1, EmailServerResponse.INTERNAL_SERVER_ERROR);
-    GoogleLoginState state = newGoogleLoginState(emailQueryUrl);
-    state.queryEmail(null);
+    GoogleLoginState state = newGoogleLoginState();
+    state.userInfoService = mockUserInfoServiceThrowingIOException();
+
+    state.queryUserInfo(mock(Credential.class));
   }
 
   @Test(expected = GoogleLoginState.EmailAddressNotReturnedException.class)
-  public void testQueryEmail_malformedContent()
+  public void testQueryUserInfo_nullUserInfoResponse()
       throws IOException, GoogleLoginState.EmailAddressNotReturnedException {
-    String emailQueryUrl = runEmailQueryServer(1, EmailServerResponse.MALFORMED_CONTENT);
-    GoogleLoginState state = newGoogleLoginState(emailQueryUrl);
-    state.queryEmail(null);
+    GoogleLoginState state = newGoogleLoginState();
+    state.userInfoService = mockUserInfoServiceReturningNullUserInfo();
+
+    state.queryUserInfo(mock(Credential.class));
   }
 
-  @Test(expected = IOException.class)
-  public void testQueryEmail_connectionClose()
+  @Test(expected = GoogleLoginState.EmailAddressNotReturnedException.class)
+  public void testQueryEmail_nullEmailUserInfoResponse()
       throws IOException, GoogleLoginState.EmailAddressNotReturnedException {
-    String emailQueryUrl = runEmailQueryServer(1, EmailServerResponse.CONNECTION_CLOSE);
-    GoogleLoginState state = newGoogleLoginState(emailQueryUrl);
-    state.queryEmail(null);
+    GoogleLoginState state = newGoogleLoginState();
+    state.userInfoService = mockUserInfoServiceReturningNullEmail();
+
+    state.queryUserInfo(mock(Credential.class));
+  }
+
+  @Test
+  public void testLogIn_IOExceptionInUserInfoRequest()
+      throws IOException, GoogleLoginState.EmailAddressNotReturnedException {
+    GoogleLoginState state = newGoogleLoginState();
+    state.userInfoService = mockUserInfoServiceThrowingIOException();
+
+    state.logInWithLocalServer(null);
+    assertFalse(state.isLoggedIn());
+    assertTrue(state.listAccounts().isEmpty());
+  }
+
+  @Test
+  public void testLogIn_nullUserInfoResponse()
+      throws IOException, GoogleLoginState.EmailAddressNotReturnedException {
+    GoogleLoginState state = newGoogleLoginState();
+    state.userInfoService = mockUserInfoServiceReturningNullUserInfo();
+
+    state.logInWithLocalServer(null);
+    assertFalse(state.isLoggedIn());
+    assertTrue(state.listAccounts().isEmpty());
+  }
+
+  @Test
+  public void testLogIn_nullEmailUserInfoResponse()
+      throws IOException, GoogleLoginState.EmailAddressNotReturnedException {
+    GoogleLoginState state = newGoogleLoginState();
+    state.userInfoService = mockUserInfoServiceReturningNullEmail();
+
+    state.logInWithLocalServer(null);
+    assertFalse(state.isLoggedIn());
+    assertTrue(state.listAccounts().isEmpty());
   }
 
   @After
   public void tearDown() throws IOException {
     authDataStore.clearStoredOAuthData();
-    if (emailServerSocket != null) {
-      emailServerSocket.close();
-    }
   }
 
-  private GoogleLoginState newGoogleLoginState(String emailQueryUrl) throws IOException {
+  private GoogleLoginState newGoogleLoginState() throws IOException {
+    UiFacade uiFacade = mock(UiFacade.class);
+    when(uiFacade.obtainVerificationCodeFromExternalUserInteraction(anyString()))
+        .thenReturn(new VerificationCodeHolder(null, null));
+
+    GoogleLoginState state = new GoogleLoginState("client-id", "client-secret", FAKE_OAUTH_SCOPES,
+        authDataStore, uiFacade, mock(LoggerFacade.class));
+    state.googleAuthorizationCodeTokenRequestCreator = mockAuthorizationCodeTokenRequestCreator();
+    state.userInfoService = mockUserInfoService();
+
+    return state;
+  }
+
+  private GoogleAuthorizationCodeTokenRequestCreator mockAuthorizationCodeTokenRequestCreator()
+      throws IOException {
     GoogleTokenResponse authResponse1 = new GoogleTokenResponse();
     authResponse1.setAccessToken("access-token-login-1");
     authResponse1.setRefreshToken("refresh-token-login-1");
@@ -316,90 +367,87 @@ public class GoogleLoginStateTest {
     authResponse3.setRefreshToken("refresh-token-login-3");
     authResponse3.setExpiresInSeconds(100L);
 
-    GoogleAuthorizationCodeTokenRequest tokenRequest =
-        mock(GoogleAuthorizationCodeTokenRequest.class);
-    when(tokenRequest.execute())
+    GoogleAuthorizationCodeTokenRequestCreator requestCreator =
+        mock(GoogleAuthorizationCodeTokenRequestCreator.class);
+    GoogleAuthorizationCodeTokenRequest request = mock(GoogleAuthorizationCodeTokenRequest.class);
+    when(request.execute())
         .thenReturn(authResponse1).thenReturn(authResponse2).thenReturn(authResponse3);
 
-    when(tokenRequestCreator.create(any(HttpTransport.class), any(JsonFactory.class),
-                                    anyString(), anyString(), anyString(), anyString()))
-        .thenReturn(tokenRequest);
+    when(requestCreator.create(any(HttpTransport.class), any(JsonFactory.class),
+                               anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(request);
 
-    when(uiFacade.obtainVerificationCodeFromExternalUserInteraction(anyString()))
-        .thenReturn(new VerificationCodeHolder(null, null));
-
-    return new GoogleLoginState("client-id", "client-secret", FAKE_OAUTH_SCOPES, authDataStore,
-        uiFacade, loggerFacade, tokenRequestCreator, emailQueryUrl);
+    return requestCreator;
   }
 
-  private enum EmailServerResponse {
-    OK, INTERNAL_SERVER_ERROR, MALFORMED_CONTENT, CONNECTION_CLOSE
-  };
+  private UserInfoService mockUserInfoService() throws IOException {
+    UserInfoService.UserInfo userInfo1 = mock(UserInfoService.UserInfo.class);
+    when(userInfo1.getEmail()).thenReturn("email-from-server-1@example.com");
+    when(userInfo1.getName()).thenReturn("account-name-1");
+    when(userInfo1.getPicture()).thenReturn("http://example.com/image-1");
 
-  private String runEmailQueryServer(int timesServing, EmailServerResponse responseType)
-      throws IOException {
-    emailServerSocket = new ServerSocket();
-    emailServerSocket.bind(null);
-    emailServerSocket.setSoTimeout(5000 /* ms */);
-    for (int i = 0; i < timesServing; i++) {
-      startQueryHandlerThread(responseType);
-    }
-    return "http://127.0.0.1:" + emailServerSocket.getLocalPort();
+    UserInfoService.UserInfo userInfo2 = mock(UserInfoService.UserInfo.class);
+    when(userInfo2.getEmail()).thenReturn("email-from-server-2@example.com");
+    when(userInfo2.getName()).thenReturn("account-name-2");
+    when(userInfo2.getPicture()).thenReturn("http://example.com/image-2");
+
+    UserInfoService.UserInfo userInfo3 = mock(UserInfoService.UserInfo.class);
+    when(userInfo3.getEmail()).thenReturn("email-from-server-3@example.com");
+    when(userInfo3.getName()).thenReturn("account-name-3");
+    when(userInfo3.getPicture()).thenReturn("http://example.com/image-3");
+
+    UserInfoService service = mock(UserInfoService.class);
+    when(service.buildAndExecuteRequest(any(HttpTransport.class), any(JsonFactory.class),
+                                        any(Credential.class), any(HttpRequestInitializer.class)))
+        .thenReturn(userInfo1).thenReturn(userInfo2).thenReturn(userInfo3);
+
+    return service;
   }
 
-  private AtomicInteger emailTagNumber = new AtomicInteger(1);
-
-  private void startQueryHandlerThread(final EmailServerResponse responseType) {
-    new Thread(new Runnable() {
-      @Override
-      public void run() {
-        try (
-            Socket socket = emailServerSocket.accept();
-            OutputStreamWriter writer =
-                new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8.name());
-        ) {
-          switch (responseType) {
-            case INTERNAL_SERVER_ERROR:
-              writer.write("HTTP/1.1 500 Server Error\n");
-              writer.write("Content-Length: 0\n\n");
-              break;
-
-            case MALFORMED_CONTENT:
-              writer.write("HTTP/1.1 200 OK\n\n");
-              writer.write("malformed-content\n\n");
-              break;
-
-            case CONNECTION_CLOSE:
-              emailServerSocket.close();
-              break;
-
-            default:
-              int tag = emailTagNumber.getAndIncrement();
-              writer.write("HTTP/1.1 200 OK\n\n");
-              writer.write("email=email-from-server-" + tag + "@example.com\n\n");
-          }
-        } catch (IOException ioe) {
-          // Not expected under normal circumstances. Ignored.
-        }
-      }
-    }).start();
+  private UserInfoService mockUserInfoServiceThrowingIOException() throws IOException {
+    UserInfoService service = mock(UserInfoService.class);
+    when(service.buildAndExecuteRequest(any(HttpTransport.class), any(JsonFactory.class),
+        any(Credential.class), any(HttpRequestInitializer.class))).thenThrow(new IOException());
+    return service;
   }
 
-  private void verifyAccountsContain(Set<Account> accounts,
-      String email, String accessToken, String refreshToken, long expiryTime) {
+  private UserInfoService mockUserInfoServiceReturningNullUserInfo() throws IOException {
+    UserInfoService service = mock(UserInfoService.class);
+    when(service.buildAndExecuteRequest(any(HttpTransport.class), any(JsonFactory.class),
+        any(Credential.class), any(HttpRequestInitializer.class))).thenReturn(null);
+    return service;
+  }
+
+  private UserInfoService mockUserInfoServiceReturningNullEmail() throws IOException {
+    UserInfoService.UserInfo userInfo = mock(UserInfoService.UserInfo.class);
+    when(userInfo.getEmail()).thenReturn(null);
+    when(userInfo.getName()).thenReturn("account-name-1");
+    when(userInfo.getPicture()).thenReturn("http://example.com/image-1");
+
+    UserInfoService service = mock(UserInfoService.class);
+    when(service.buildAndExecuteRequest(any(HttpTransport.class), any(JsonFactory.class),
+        any(Credential.class), any(HttpRequestInitializer.class))).thenReturn(userInfo);
+    return service;
+  }
+
+  private void verifyAccountsContain(Set<Account> accounts, String email, String accessToken,
+      String refreshToken, long expiryTime, String name, String avatarUrl) {
     ArrayList<Account> accountList = new ArrayList<>(accounts);
-    int index = accountList.indexOf(new Account(email, mock(Credential.class)));
+    int index = accountList.indexOf(new Account(email, mock(Credential.class), null, null));
     assertNotEquals(-1, index);
-    verifyAccountEquals(accountList.get(index), email, accessToken, refreshToken, expiryTime);
+    verifyAccountEquals(accountList.get(index),
+        email, accessToken, refreshToken, expiryTime, name, avatarUrl);
   }
 
-  private void verifyAccountEquals(Account account,
-      String email, String accessToken, String refreshToken, long expiryTime) {
+  private void verifyAccountEquals(Account account, String email, String accessToken,
+      String refreshToken, long expiryTime, String name, String avatarUrl) {
     assertEquals(email, account.getEmail());
     assertEquals(accessToken, account.getAccessToken());
     assertEquals(refreshToken, account.getRefreshToken());
     if (expiryTime != -1) {
       assertEquals(expiryTime, account.getAccessTokenExpiryTime());
     }
+    assertEquals(name, account.getName());
+    assertEquals(avatarUrl, account.getAvatarUrl());
   }
 }

--- a/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/JavaPreferenceOAuthDataStoreTest.java
@@ -44,9 +44,12 @@ public class JavaPreferenceOAuthDataStoreTest {
       new HashSet<>(Arrays.asList("my-scope1", "my-scope2")));
 
   private static final OAuthData[] fakeOAuthData = new OAuthData[] {
-      new OAuthData("accessToken1", "refreshToken1", "email1@example.com", FAKE_OAUTH_SCOPES, 123),
-      new OAuthData("accessToken2", "refreshToken2", "email2@example.com", FAKE_OAUTH_SCOPES, 234),
-      new OAuthData("accessToken3", "refreshToken3", "email3@example.com", FAKE_OAUTH_SCOPES, 345)
+      new OAuthData("accessToken1", "refreshToken1", "email1@example.com",
+                    "name1", "http://example.com/image1", FAKE_OAUTH_SCOPES, 123),
+      new OAuthData("accessToken2", "refreshToken2", "email2@example.com",
+                    "name2", "http://example.com/image2", FAKE_OAUTH_SCOPES, 234),
+      new OAuthData("accessToken3", "refreshToken3", "email3@example.com",
+                    "name3", "http://example.com/image3", FAKE_OAUTH_SCOPES, 345)
   };
 
   @Mock private LoggerFacade logger;
@@ -67,24 +70,28 @@ public class JavaPreferenceOAuthDataStoreTest {
 
   @Test
   public void testSaveLoadOAuthData_nullValues() {
-    dataStore.saveOAuthData(new OAuthData(null, null, "email@example.com", null, 0));
+    dataStore.saveOAuthData(new OAuthData(null, null, "email@example.com", null, null, null, 0));
     OAuthData loaded = dataStore.loadOAuthData().iterator().next();
 
     assertNull(loaded.getAccessToken());
     assertNull(loaded.getRefreshToken());
     assertEquals("email@example.com", loaded.getEmail());
+    assertNull(loaded.getName());
+    assertNull(loaded.getAvatarUrl());
     assertTrue(loaded.getStoredScopes().isEmpty());
     assertEquals(0, loaded.getAccessTokenExpiryTime());
   }
 
   @Test
   public void testSaveLoadOAuthData_emptyValues() {
-    dataStore.saveOAuthData(new OAuthData("", "", "email@example.com", null, 0));
+    dataStore.saveOAuthData(new OAuthData("", "", "email@example.com", "", "", null, 0));
     OAuthData loaded = dataStore.loadOAuthData().iterator().next();
 
     assertNull(loaded.getAccessToken());
     assertNull(loaded.getRefreshToken());
     assertEquals("email@example.com", loaded.getEmail());
+    assertNull(loaded.getName());
+    assertNull(loaded.getAvatarUrl());
     assertTrue(loaded.getStoredScopes().isEmpty());
     assertEquals(0, loaded.getAccessTokenExpiryTime());
   }
@@ -98,20 +105,23 @@ public class JavaPreferenceOAuthDataStoreTest {
 
   @Test
   public void testSaveLoadOAuthData_nullScopeSet() {
-    dataStore.saveOAuthData(new OAuthData("accessToken", "refreshToken", "email", null, 123));
+    dataStore.saveOAuthData(
+        new OAuthData("accessToken", "refreshToken", "email", "name", "avatarUrl", null, 123));
     OAuthData loaded = dataStore.loadOAuthData().iterator().next();
 
     assertEquals("accessToken", loaded.getAccessToken());
     assertEquals("refreshToken", loaded.getRefreshToken());
     assertEquals("email", loaded.getEmail());
+    assertEquals("name", loaded.getName());
+    assertEquals("avatarUrl", loaded.getAvatarUrl());
     assertTrue(loaded.getStoredScopes().isEmpty());
     assertEquals(123, loaded.getAccessTokenExpiryTime());
   }
 
   @Test
   public void testSaveLoadOAuthData_emptyScopeSet() {
-    OAuthData oAuthData =
-        new OAuthData("accessToken", "refreshToken", "email", new HashSet<String>(), 123);
+    OAuthData oAuthData = new OAuthData(
+        "accessToken", "refreshToken", "email", "name", "avatarUrl", new HashSet<String>(), 123);
 
     dataStore.saveOAuthData(oAuthData);
     Set<OAuthData> loaded = dataStore.loadOAuthData();
@@ -123,14 +133,14 @@ public class JavaPreferenceOAuthDataStoreTest {
   public void testSaveOAuthData_scopeWithDelimiter() {
     Set<String> scopes = new HashSet<>(Arrays.asList(JavaPreferenceOAuthDataStore.SCOPE_DELIMITER,
         "head" + JavaPreferenceOAuthDataStore.SCOPE_DELIMITER + "tail"));
-    OAuthData oAuthData = new OAuthData(null, null, "email@example.com", scopes, 0);
+    OAuthData oAuthData = new OAuthData(null, null, "email@example.com", null, null, scopes, 0);
 
     dataStore.saveOAuthData(oAuthData);
   }
 
   @Test
   public void testSaveLoadOAuthData_emptyEmail() {
-    dataStore.saveOAuthData(new OAuthData(null, null, "", null, 0));
+    dataStore.saveOAuthData(new OAuthData(null, null, "", null, null, null, 0));
     assertTrue(dataStore.loadOAuthData().isEmpty());
   }
 

--- a/src/test/java/com/google/cloud/tools/ide/login/OAuthDataTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/login/OAuthDataTest.java
@@ -25,27 +25,39 @@ import java.util.Set;
 
 public class OAuthDataTest {
 
-  private Set<String> scopes = ImmutableSet.of("scope 1", "scope 2");
+  private Set<String> scopes = ImmutableSet.of("scope_1", "scope_2");
   
-  private OAuthData data = new OAuthData("access token", "refresh token", "storedEmail@example.com",
-      scopes, 10);
+  private OAuthData data = new OAuthData("access_token", "refresh_token", "storedEmail@example.com",
+      "account_name", "http://example.com/avatar_image", scopes, 10);
 
   @Test
   public void testNullable() {
-    data = new OAuthData(null, null, "email@example.com", null, 10);
+    data = new OAuthData(null, null, "email@example.com", null, null, null, 10);
     Assert.assertNull(data.getRefreshToken());
     Assert.assertNull(data.getAccessToken());
+    Assert.assertNull(data.getName());
+    Assert.assertNull(data.getAvatarUrl());
     Assert.assertTrue(data.getStoredScopes().isEmpty());
   }
 
   @Test(expected = NullPointerException.class)
   public void testNullEmail() {
-    new OAuthData(null, null, null, null, 10);
+    new OAuthData("access_token", "refresh_token", null, "name", "http://example.com", scopes, 10);
   }
 
   @Test
   public void testGetEmail() {
     Assert.assertEquals("storedEmail@example.com", data.getEmail());
+  }
+
+  @Test
+  public void testGetName() {
+    Assert.assertEquals("account_name", data.getName());
+  }
+
+  @Test
+  public void testGetAvatarUrl() {
+    Assert.assertEquals("http://example.com/avatar_image", data.getAvatarUrl());
   }
 
   @Test
@@ -55,12 +67,12 @@ public class OAuthDataTest {
 
   @Test
   public void testGetAccessToken() {
-    Assert.assertEquals("access token", data.getAccessToken());
+    Assert.assertEquals("access_token", data.getAccessToken());
   }
 
   @Test
   public void testGetRefreshToken() {
-    Assert.assertEquals("refresh token", data.getRefreshToken());
+    Assert.assertEquals("refresh_token", data.getRefreshToken());
   }
 
   @Test


### PR DESCRIPTION
Fixes #24.

Account name and avatar URL are queried through [Google OAuth2 API](https://developers.google.com/apis-explorer/#p/oauth2/v2/oauth2.userinfo.get). Basically, you do

```java
Oauth2 oAuth2 = Oauth2.Builder(...).build();
Userinfoplus userInfo = oAuth2.userinfo().get().execute();
```

and the result `userInfo` contains an email, an account name, and an avatar URL. Very convenient.

(`userInfo` already contains an email, so the previous low-level logic to directly accessing `https://www.googleapis.com/userinfo/email` and manually parsing the response is no longer necessary.)

Notes:
- Email cannot be null, as before. Name and avatar URL may. If an email cannot be retrieved for any reason, login is considered failed.
- `UserInfoService` is a wrapper around `Oauth2.Builder` and `Userinfoplus`. The new class is to enable unit testing, since Mockito cannot mock some of the OAuth2 API classes. (They are `final`.)
- `URL` --> `String` for `avatarUrl`: after some tinkering, it looks like `String` is better suited.
- Query timeout is now set through `HttpRequestInitializer`.
