### PR TITLE
Prepare requirements for publishing to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,21 +30,18 @@
     <developer>
       <id>elharo</id>
       <name>Elliotte Harold</name>
-      <email>elharo@google.com</email>
       <organization>Google</organization>
       <organizationUrl>https://www.google.com</organizationUrl>
     </developer>
     <developer>
       <id>chanseok</id>
       <name>Chanseok Oh</name>
-      <email>chanseok@google.com</email>
       <organization>Google</organization>
       <organizationUrl>https://www.google.com</organizationUrl>
     </developer>
     <developer>
       <id>bsd</id>
       <name>Brian de Alwis</name>
-      <email>bsd@mt.ca</email>
       <organization>Manumitting Technologies</organization>
       <organizationUrl>https://manumitting.com</organizationUrl>
     </developer>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
       <id>bsd</id>
       <name>Brian de Alwis</name>
       <organization>Manumitting Technologies</organization>
-      <organizationUrl>https://manumitting.com</organizationUrl>
+      <organizationUrl>http://manumitting.com</organizationUrl>
     </developer>
   </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <organization>
     <name>Google Inc.</name>
-    <url>http://www.google.com</url>
+    <url>https://www.google.com</url>
   </organization>
 
   <licenses>
@@ -32,21 +32,21 @@
       <name>Elliotte Harold</name>
       <email>elharo@google.com</email>
       <organization>Google</organization>
-      <organizationUrl>http://www.google.com</organizationUrl>
+      <organizationUrl>https://www.google.com</organizationUrl>
     </developer>
     <developer>
       <id>chanseok</id>
       <name>Chanseok Oh</name>
       <email>chanseok@google.com</email>
       <organization>Google</organization>
-      <organizationUrl>http://www.google.com</organizationUrl>
+      <organizationUrl>https://www.google.com</organizationUrl>
     </developer>
     <developer>
       <id>bsd</id>
       <name>Brian de Alwis</name>
       <email>bsd@mt.ca</email>
       <organization>Manumitting Technologies</organization>
-      <organizationUrl>http://manumitting.com</organizationUrl>
+      <organizationUrl>https://manumitting.com</organizationUrl>
     </developer>
   </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
   <url>https://github.com/GoogleCloudPlatform/ide-login</url>
 
   <organization>
-    <name>Google Inc.</name>
-    <url>https://www.google.com</url>
+    <name>Google Cloud Platform</name>
+    <url>https://cloud.google.com</url>
   </organization>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.cloud.tools.login</groupId>
-  <artifactId>google-login-common</artifactId>
+  <artifactId>plugins-login-common</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,19 +86,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <version>3.0.1</version>
@@ -177,6 +164,19 @@
       <id>release</id>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,9 @@
   <version>0.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>IDE Login Support for Google Cloud Tools</name>
+  <name>Login Support for Google Cloud Tools</name>
   <description>
-    A library providing a common framework for Google login support on IDEs for Google Cloud Tools.
+    A library providing a common framework for Google login support for Google Cloud Tools.
   </description>
   <url>https://github.com/GoogleCloudPlatform/ide-login</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,27 +5,99 @@
 
   <groupId>com.google.cloud.tools.ide.login</groupId>
   <artifactId>google-ide-login</artifactId>
-  <version>0.0.0-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
-  <name>Login Support for Google Cloud Tools</name>
+  <name>IDE Login Support for Google Cloud Tools</name>
+  <description>
+    A library providing a common framework for Google login support on IDEs for Google Cloud Tools.
+  </description>
+  <url>https://github.com/GoogleCloudPlatform/ide-login</url>
+
+  <organization>
+    <name>Google Inc.</name>
+    <url>http://www.google.com</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>elharo</id>
+      <name>Elliotte Harold</name>
+      <email>elharo@google.com</email>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>chanseok</id>
+      <name>Chanseok Oh</name>
+      <email>chanseok@google.com</email>
+      <organization>Google</organization>
+      <organizationUrl>http://www.google.com</organizationUrl>
+    </developer>
+    <developer>
+      <id>bsd</id>
+      <name>Brian de Alwis</name>
+      <email>bsd@mt.ca</email>
+      <organization>Manumitting Technologies</organization>
+      <organizationUrl>http://manumitting.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/GoogleCloudPlatform/ide-login.git</connection>
+    <developerConnection>scm:git:https://github.com/GoogleCloudPlatform/ide-login.git</developerConnection>
+    <url>https://github.com/GoogleCloudPlatform/ide-login</url>
+  </scm>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+
+  <distributionManagement>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <name>Sonatype Nexus Staging</name>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.0.2</version>
         <configuration>
-          <archive>  
+          <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-          </archive> 
+          </archive>
         </configuration>
-      </plugin>  
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.0.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -39,9 +111,9 @@
           <execution>
             <id>bundle-manifest</id>
             <phase>process-classes</phase>
-            <goals>    
+            <goals>
               <goal>manifest</goal>
-            </goals>   
+            </goals>
           </execution>
         </executions>
       </plugin>
@@ -97,7 +169,47 @@
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
-    
+
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.10.4</version>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
I consulted `pom.xml` of `appengine-plugins-core`.

- Some required info: name, description, license, developers, scm.
- Adding deploy destinations (?): sonatype-staging and sonatype-snapshot. My guess is that `mvn deploy` will push things to these repositories (based on whether the version ends with `-SNAPSHOT` or not).
- Adding a profile `release`.

I'll continue to look into this PR next week.