### PR TITLE
Bump to 0.1.1-SNAPSHOT after 0.1.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.google.cloud.tools.login</groupId>
   <artifactId>plugins-login-common</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Login Support for Google Cloud Tools</name>


### PR DESCRIPTION
0.1.0 is now available on Maven Central.