### PR TITLE
Catch and report exceptions when persisting account details

### DIFF
--- a/src/main/java/com/google/cloud/tools/login/OAuthDataStore.java
+++ b/src/main/java/com/google/cloud/tools/login/OAuthDataStore.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.login;
 
+import java.io.IOException;
 import java.util.Set;
 
 /**
@@ -27,22 +28,22 @@ public interface OAuthDataStore {
   /**
    * Stores a specified {@link OAuthData} object persistently.
    */
-  void saveOAuthData(OAuthData oAuthData);
+  void saveOAuthData(OAuthData oAuthData) throws IOException;
 
   /**
    * Retrieves the persistently stored {@link OAuthData} objects, if any.
    * 
    * @return never {@code null}
    */
-  Set<OAuthData> loadOAuthData();
+  Set<OAuthData> loadOAuthData() throws IOException;
 
   /**
    * Removes a stored {@link OAuthData} matching the given {@code email}, in any.
    */
-  void removeOAuthData(String email);
+  void removeOAuthData(String email) throws IOException;
 
   /**
    * Clears the persistently stored {@link OAuthData} object, if any.
    */
-  void clearStoredOAuthData();
+  void clearStoredOAuthData() throws IOException;
 }

--- a/src/test/java/com/google/cloud/tools/login/GoogleLoginStateTest.java
+++ b/src/test/java/com/google/cloud/tools/login/GoogleLoginStateTest.java
@@ -169,7 +169,7 @@ public class GoogleLoginStateTest {
   @Test
   public void testFailurePersistingAccounts() throws IOException {
     authDataStore = mock(OAuthDataStore.class);
-    doThrow(new SecurityException()).when(authDataStore).saveOAuthData(any(OAuthData.class));
+    doThrow(new IOException()).when(authDataStore).saveOAuthData(any(OAuthData.class));
     GoogleLoginState state = newGoogleLoginState();
     
     state.logInWithLocalServer(null /* no title */);

--- a/src/test/java/com/google/cloud/tools/login/JavaPreferenceOAuthDataStoreExceptionTest.java
+++ b/src/test/java/com/google/cloud/tools/login/JavaPreferenceOAuthDataStoreExceptionTest.java
@@ -16,10 +16,11 @@
 
 package com.google.cloud.tools.login;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
@@ -37,7 +38,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Test that exceptions raised on load or save are turned to IOExceptions
+ * Test that exceptions raised on load or save are turned into IOExceptions
  */
 @RunWith(Parameterized.class)
 public class JavaPreferenceOAuthDataStoreExceptionTest {
@@ -56,9 +57,11 @@ public class JavaPreferenceOAuthDataStoreExceptionTest {
   private ExceptionRaisingPreferenceWrapper root;
   private JavaPreferenceOAuthDataStore dataStore;
   private LoggerFacade loggerFacade;
+  private Throwable thrownException;
 
   public JavaPreferenceOAuthDataStoreExceptionTest(Exception exception) {
     loggerFacade = mock(LoggerFacade.class);
+    thrownException = exception;
     root = new ExceptionRaisingPreferenceWrapper(exception);
     dataStore = new JavaPreferenceOAuthDataStore("path", loggerFacade, root); //$NON-NLS-1$
   }
@@ -69,7 +72,7 @@ public class JavaPreferenceOAuthDataStoreExceptionTest {
       dataStore.saveOAuthData(fakeOAuthData);
       fail("should have thrown an IOException"); //$NON-NLS-1$
     } catch (IOException ex) {
-      // expected
+      assertEquals("should have nested exception", thrownException, ex.getCause()); //$NON-NLS-1$
     }
   }
 
@@ -79,7 +82,7 @@ public class JavaPreferenceOAuthDataStoreExceptionTest {
       dataStore.removeOAuthData("email1@example.com"); //$NON-NLS-1$
       fail("should have thrown an IOException"); //$NON-NLS-1$
     } catch (IOException ex) {
-      // expected
+      assertEquals("should have nested exception", thrownException, ex.getCause()); //$NON-NLS-1$
     }
   }
 
@@ -89,7 +92,7 @@ public class JavaPreferenceOAuthDataStoreExceptionTest {
       dataStore.loadOAuthData();
       fail("should have thrown an IOException"); //$NON-NLS-1$
     } catch (IOException ex) {
-      // expected
+      assertEquals("should have nested exception", thrownException, ex.getCause()); //$NON-NLS-1$
     }
   }
 

--- a/src/test/java/com/google/cloud/tools/login/JavaPreferenceOAuthDataStoreExceptionTest.java
+++ b/src/test/java/com/google/cloud/tools/login/JavaPreferenceOAuthDataStoreExceptionTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.login;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import com.google.api.client.repackaged.com.google.common.base.Strings;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.NodeChangeListener;
+import java.util.prefs.PreferenceChangeListener;
+import java.util.prefs.Preferences;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Test that exceptions raised on load or save are turned to IOExceptions
+ */
+@RunWith(Parameterized.class)
+public class JavaPreferenceOAuthDataStoreExceptionTest {
+
+  // The different exceptions that may be raised by Java Preferences.
+  @Parameters
+  public static Iterable<Exception> parameters() {
+    return Arrays.asList(new SecurityException(), new BackingStoreException("")); //$NON-NLS-1$
+  }
+
+  private static final Set<String> FAKE_OAUTH_SCOPES = Collections.singleton("scope1"); //$NON-NLS-1$
+
+  private static final OAuthData fakeOAuthData = new OAuthData("accessToken1", "refreshToken1", //$NON-NLS-1$ //$NON-NLS-2$
+      "email1@example.com", "name1", "http://example.com/image1", FAKE_OAUTH_SCOPES, 123); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+  private ExceptionRaisingPreferenceWrapper root;
+  private JavaPreferenceOAuthDataStore dataStore;
+  private LoggerFacade loggerFacade;
+
+  public JavaPreferenceOAuthDataStoreExceptionTest(Exception exception) {
+    loggerFacade = mock(LoggerFacade.class);
+    root = new ExceptionRaisingPreferenceWrapper(exception);
+    dataStore = new JavaPreferenceOAuthDataStore("path", loggerFacade, root); //$NON-NLS-1$
+  }
+
+  @Test
+  public void testSaveOAuthData() throws IOException {
+    try {
+      dataStore.saveOAuthData(fakeOAuthData);
+      fail("should have thrown an IOException"); //$NON-NLS-1$
+    } catch (IOException ex) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testRemoveOAuthData() throws IOException {
+    try {
+      dataStore.removeOAuthData("email1@example.com"); //$NON-NLS-1$
+      fail("should have thrown an IOException"); //$NON-NLS-1$
+    } catch (IOException ex) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testLoadOAuthData() throws IOException {
+    try {
+      dataStore.loadOAuthData();
+      fail("should have thrown an IOException"); //$NON-NLS-1$
+    } catch (IOException ex) {
+      // expected
+    }
+  }
+
+  /**
+   * A wrapper that throws the given exception on load or save.
+   */
+  final class ExceptionRaisingPreferenceWrapper extends Preferences {
+    private String name;
+    private ExceptionRaisingPreferenceWrapper parent;
+    private Map<String, Object> values = new HashMap<>();
+    private Map<String, ExceptionRaisingPreferenceWrapper> children = new HashMap<>();
+    private Exception exception;
+
+    ExceptionRaisingPreferenceWrapper(Exception exception) {
+      this.exception = exception;
+      this.name = ""; //$NON-NLS-1$
+    }
+
+    ExceptionRaisingPreferenceWrapper(ExceptionRaisingPreferenceWrapper parent, String name,
+        Exception exception) {
+      this(exception);
+      this.parent = parent;
+      this.name = name;
+    }
+
+    private void throwException() throws BackingStoreException {
+      if (exception instanceof BackingStoreException) {
+        throw (BackingStoreException) exception;
+      }
+      throw (RuntimeException) exception;
+    }
+
+    public void removeNode() throws BackingStoreException {
+      throwException();
+    }
+
+    public void flush() throws BackingStoreException {
+      throwException();
+    }
+
+    public void sync() throws BackingStoreException {
+      throwException();
+    }
+
+    public void clear() throws BackingStoreException {
+      throwException();
+    }
+
+    public String[] childrenNames() throws BackingStoreException {
+      throwException();
+      return children.keySet().toArray(new String[children.size()]);
+    }
+
+    public Preferences parent() {
+      return parent;
+    }
+
+    public Preferences node(String pathName) {
+      if (Strings.isNullOrEmpty(pathName)) {
+        return this;
+      }
+      if (pathName.startsWith("/")) { //$NON-NLS-1$
+        if (parent != null) {
+          return parent.node(pathName);
+        }
+        pathName = pathName.substring(1);
+      }
+      int slash = pathName.indexOf('/');
+      String childName = slash > 0 ? pathName.substring(0, slash) : pathName;
+      String remainder = slash > 0 ? pathName.substring(slash + 1) : ""; //$NON-NLS-1$
+      ExceptionRaisingPreferenceWrapper child = children.get(childName);
+      if (child == null) {
+        children.put(childName,
+            child = new ExceptionRaisingPreferenceWrapper(this, childName, exception));
+      }
+      return child.node(remainder);
+    }
+
+    public boolean nodeExists(String pathName) throws BackingStoreException {
+      throwException();
+      if (Strings.isNullOrEmpty(pathName)) {
+        return true;
+      }
+      if (pathName.startsWith("/")) { //$NON-NLS-1$
+        if (parent != null) {
+          return parent.nodeExists(pathName);
+        }
+        pathName = pathName.substring(1);
+      }
+      int slash = pathName.indexOf('/');
+      String childName = slash > 0 ? pathName.substring(0, slash) : pathName;
+      String remainder = slash > 0 ? pathName.substring(slash + 1) : ""; //$NON-NLS-1$
+      Preferences child = children.get(childName);
+      if (child == null) {
+        return false;
+      }
+      return child.nodeExists(remainder);
+    }
+
+
+    public void put(String key, String value) {
+      values.put(key, value);
+    }
+
+    public String get(String key, String def) {
+      return values.containsKey(key) ? (String) values.get(key) : def;
+    }
+
+    public void remove(String key) {
+      values.remove(key);
+    }
+
+    public void putInt(String key, int value) {
+      values.put(key, value);
+    }
+
+    public int getInt(String key, int def) {
+      return values.containsKey(key) ? (Integer) values.get(key) : def;
+    }
+
+    public void putLong(String key, long value) {
+      values.put(key, value);
+    }
+
+    public long getLong(String key, long def) {
+      return values.containsKey(key) ? (Long) values.get(key) : def;
+    }
+
+    public void putBoolean(String key, boolean value) {
+      values.put(key, value);
+    }
+
+    public boolean getBoolean(String key, boolean def) {
+      return values.containsKey(key) ? (Boolean) values.get(key) : def;
+    }
+
+    public void putFloat(String key, float value) {
+      values.put(key, value);
+    }
+
+    public float getFloat(String key, float def) {
+      return values.containsKey(key) ? (Float) values.get(key) : def;
+    }
+
+    public void putDouble(String key, double value) {
+      values.put(key, value);
+    }
+
+    public double getDouble(String key, double def) {
+      return values.containsKey(key) ? (Double) values.get(key) : def;
+    }
+
+    public void putByteArray(String key, byte[] value) {
+      values.put(key, value);
+    }
+
+    public byte[] getByteArray(String key, byte[] def) {
+      return values.containsKey(key) ? (byte[]) values.get(key) : def;
+    }
+
+    public String[] keys() throws BackingStoreException {
+      return values.keySet().toArray(new String[values.size()]);
+    }
+
+    public String name() {
+      return name;
+    }
+
+    public String absolutePath() {
+      if (parent == null) {
+        return name;
+      }
+      return parent.absolutePath() + "/" + name; //$NON-NLS-1$
+    }
+
+    public boolean isUserNode() {
+      return true;
+    }
+
+    public String toString() {
+      return name;
+    }
+
+    public void addPreferenceChangeListener(PreferenceChangeListener pcl) {
+    }
+
+    public void removePreferenceChangeListener(PreferenceChangeListener pcl) {
+    }
+
+    public void addNodeChangeListener(NodeChangeListener ncl) {
+    }
+
+    public void removeNodeChangeListener(NodeChangeListener ncl) {
+    }
+
+    public void exportNode(OutputStream os) throws IOException, BackingStoreException {
+    }
+
+    public void exportSubtree(OutputStream os) throws IOException, BackingStoreException {
+    }
+  }
+}

--- a/src/test/java/com/google/cloud/tools/login/JavaPreferenceOAuthDataStoreTest.java
+++ b/src/test/java/com/google/cloud/tools/login/JavaPreferenceOAuthDataStoreTest.java
@@ -21,12 +21,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -34,6 +29,11 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JavaPreferenceOAuthDataStoreTest {
@@ -58,18 +58,18 @@ public class JavaPreferenceOAuthDataStoreTest {
       new JavaPreferenceOAuthDataStore(TEST_PREFERENCE_PATH, logger);
 
   @Test
-  public void testLoadOAuthData_returnEmptyOAuthData() {
+  public void testLoadOAuthData_returnEmptyOAuthData() throws IOException {
     assertTrue(dataStore.loadOAuthData().isEmpty());
   }
 
   @Test
-  public void testSaveLoadOAuthData() {
+  public void testSaveLoadOAuthData() throws IOException {
     dataStore.saveOAuthData(fakeOAuthData[0]);
     verifyContains(dataStore.loadOAuthData(), fakeOAuthData[0]);
   }
 
   @Test
-  public void testSaveLoadOAuthData_nullValues() {
+  public void testSaveLoadOAuthData_nullValues() throws IOException {
     dataStore.saveOAuthData(new OAuthData(null, null, "email@example.com", null, null, null, 0));
     OAuthData loaded = dataStore.loadOAuthData().iterator().next();
 
@@ -83,7 +83,7 @@ public class JavaPreferenceOAuthDataStoreTest {
   }
 
   @Test
-  public void testSaveLoadOAuthData_emptyValues() {
+  public void testSaveLoadOAuthData_emptyValues() throws IOException {
     dataStore.saveOAuthData(new OAuthData("", "", "email@example.com", "", "", null, 0));
     OAuthData loaded = dataStore.loadOAuthData().iterator().next();
 
@@ -97,14 +97,14 @@ public class JavaPreferenceOAuthDataStoreTest {
   }
 
   @Test
-  public void testSaveClearLoadOAuthData() {
+  public void testSaveClearLoadOAuthData() throws IOException {
     saveThreeFakeOAuthData();
     dataStore.clearStoredOAuthData();
     assertTrue(dataStore.loadOAuthData().isEmpty());
   }
 
   @Test
-  public void testSaveLoadOAuthData_nullScopeSet() {
+  public void testSaveLoadOAuthData_nullScopeSet() throws IOException {
     dataStore.saveOAuthData(
         new OAuthData("accessToken", "refreshToken", "email", "name", "avatarUrl", null, 123));
     OAuthData loaded = dataStore.loadOAuthData().iterator().next();
@@ -119,7 +119,7 @@ public class JavaPreferenceOAuthDataStoreTest {
   }
 
   @Test
-  public void testSaveLoadOAuthData_emptyScopeSet() {
+  public void testSaveLoadOAuthData_emptyScopeSet() throws IOException {
     OAuthData oAuthData = new OAuthData(
         "accessToken", "refreshToken", "email", "name", "avatarUrl", new HashSet<String>(), 123);
 
@@ -130,7 +130,7 @@ public class JavaPreferenceOAuthDataStoreTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testSaveOAuthData_scopeWithDelimiter() {
+  public void testSaveOAuthData_scopeWithDelimiter() throws IOException {
     Set<String> scopes = new HashSet<>(Arrays.asList(JavaPreferenceOAuthDataStore.SCOPE_DELIMITER,
         "head" + JavaPreferenceOAuthDataStore.SCOPE_DELIMITER + "tail"));
     OAuthData oAuthData = new OAuthData(null, null, "email@example.com", null, null, scopes, 0);
@@ -139,13 +139,13 @@ public class JavaPreferenceOAuthDataStoreTest {
   }
 
   @Test
-  public void testSaveLoadOAuthData_emptyEmail() {
+  public void testSaveLoadOAuthData_emptyEmail() throws IOException {
     dataStore.saveOAuthData(new OAuthData(null, null, "", null, null, null, 0));
     assertTrue(dataStore.loadOAuthData().isEmpty());
   }
 
   @Test
-  public void testSaveLoadOAuthData_multipleCredentials() {
+  public void testSaveLoadOAuthData_multipleCredentials() throws IOException {
     saveThreeFakeOAuthData();
 
     Set<OAuthData> loaded = dataStore.loadOAuthData();
@@ -156,7 +156,7 @@ public class JavaPreferenceOAuthDataStoreTest {
   }
 
   @Test
-  public void testRemoveOAuthData() {
+  public void testRemoveOAuthData() throws IOException {
     saveThreeFakeOAuthData();
     dataStore.removeOAuthData("email1@example.com");
     dataStore.removeOAuthData("email3@example.com");
@@ -166,7 +166,7 @@ public class JavaPreferenceOAuthDataStoreTest {
   }
 
   @Test
-  public void testRemoveOAuthData_nonExistingEmail() {
+  public void testRemoveOAuthData_nonExistingEmail() throws IOException {
     saveThreeFakeOAuthData();
     dataStore.removeOAuthData("email999@example.com");
 
@@ -178,18 +178,19 @@ public class JavaPreferenceOAuthDataStoreTest {
   }
 
   @After
-  public void tearDown() throws BackingStoreException {
+  public void tearDown() throws BackingStoreException, IOException {
     dataStore.clearStoredOAuthData();
     Preferences.userRoot().node(TEST_PREFERENCE_PATH).removeNode();
   }
 
-  private void saveThreeFakeOAuthData() {
+  private void saveThreeFakeOAuthData() throws IOException {
     dataStore.saveOAuthData(fakeOAuthData[0]);
     dataStore.saveOAuthData(fakeOAuthData[1]);
     dataStore.saveOAuthData(fakeOAuthData[2]);
   }
 
-  private void verifyContains(Set<OAuthData> oAuthDataSet, OAuthData oAuthDataToMatch) {
+  private void verifyContains(Set<OAuthData> oAuthDataSet, OAuthData oAuthDataToMatch)
+      throws IOException {
     for (OAuthData oAuthData : oAuthDataSet) {
       if (Objects.equals(oAuthData.getEmail(), oAuthDataToMatch.getEmail())
           && Objects.equals(oAuthData.getAccessToken(), oAuthDataToMatch.getAccessToken())


### PR DESCRIPTION
Here's a first stab at #51 that catches and reports all exceptions when persisting accounts to the `OAuthDataStore`. I wasn't sure if it was worth reporting the exception messages to the user.  But then again our users are developers and shouldn't be scared by an exception message.

Note that the `JavaPreferenceOAuthDataStore` does catch `java.util.prefs.BackingStoreException`.

Maybe we should just have a separate `OAuthDataStoreException` and have the implementations wrap and throw exceptions.